### PR TITLE
🧪 [Testing] Add edge case tests for Complex State panic behavior

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -138,3 +138,23 @@ where
         Complex::new(T::zero(), T::zero())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use num_complex::Complex;
+
+    #[test]
+    #[should_panic(expected = "Index out of bounds")]
+    fn test_complex_state_get_out_of_bounds() {
+        let c: Complex<f64> = Complex::new(1.0, 2.0);
+        c.get(2);
+    }
+
+    #[test]
+    #[should_panic(expected = "Index out of bounds")]
+    fn test_complex_state_set_out_of_bounds() {
+        let mut c: Complex<f64> = Complex::new(1.0, 2.0);
+        c.set(2, 3.0);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing edge case tests for the `Complex` state `get` and `set` methods panic behavior when an out-of-bounds index is used.
📊 **Coverage:** What scenarios are now tested: Out-of-bounds index access (`index >= 2`) for both `get` and `set` on a `Complex` state.
✨ **Result:** The improvement in test coverage: Added explicit tests that verify the expected panic message "Index out of bounds" using the `#[should_panic]` attribute.

---
*PR created automatically by Jules for task [10823222366069911219](https://jules.google.com/task/10823222366069911219) started by @Ryan-D-Gast*