### PR TITLE
🧪 Add edge case tests for State panic behavior

### DIFF
--- a/patch_complex_test.sh
+++ b/patch_complex_test.sh
@@ -1,0 +1,1 @@
+sed -i 's/state.set(2, 3.0);/state.set(2, 3.0);/' src/traits.rs

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -138,3 +138,36 @@ where
         Complex::new(T::zero(), T::zero())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(expected = "Index out of bounds")]
+    fn test_state_f64_get_out_of_bounds() {
+        let state: f64 = 1.0;
+        let _ = state.get(1);
+    }
+
+    #[test]
+    #[should_panic(expected = "Index out of bounds")]
+    fn test_state_f64_set_out_of_bounds() {
+        let mut state: f64 = 1.0;
+        state.set(1, 2.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Index out of bounds")]
+    fn test_state_complex_get_out_of_bounds() {
+        let state = Complex::new(1.0, 2.0);
+        let _ = state.get(2);
+    }
+
+    #[test]
+    #[should_panic(expected = "Index out of bounds")]
+    fn test_state_complex_set_out_of_bounds() {
+        let mut state = Complex::new(1.0, 2.0);
+        state.set(2, 3.0);
+    }
+}


### PR DESCRIPTION
This commit adds unit tests to `src/traits.rs` to verify that `get()` and `set()` correctly panic with "Index out of bounds" when an invalid index is provided to implementations of the `State` trait, specifically testing the primitive `f64` type and the `Complex<f64>` type.

---
*PR created automatically by Jules for task [3109245789362728913](https://jules.google.com/task/3109245789362728913) started by @Ryan-D-Gast*