### PR TITLE
🔒 fix: replace panic with error result in singular matrix solve

### DIFF
--- a/src/linalg/matrix/linear.rs
+++ b/src/linalg/matrix/linear.rs
@@ -69,9 +69,7 @@ impl<T: Real> Matrix<T> {
             // Check for singularity
             if pivot_val <= eps {
                 // Note the t, y are not known here and should be updated by caller before returning to user
-                return Err(Error::LinearAlgebra {
-                    msg: "Singular matrix encountered".into(),
-                });
+                return Err(crate::linalg::LinalgError::Singular { step: k + 1 }.into());
             }
 
             if pivot_row != k {
@@ -124,7 +122,7 @@ impl<T: Real> Matrix<T> {
     }
 
     /// In-place solve: overwrites `b` with `x`.
-    pub fn lin_solve_mut(&self, b: &mut [T]) {
+    pub fn lin_solve_mut(&self, b: &mut [T]) -> Result<(), crate::linalg::LinalgError> {
         let n = self.n;
         assert_eq!(
             b.len(),
@@ -174,7 +172,7 @@ impl<T: Real> Matrix<T> {
                 }
             }
             if pivot_val == T::zero() {
-                panic!("singular matrix in solve");
+                return Err(crate::linalg::LinalgError::Singular { step: k + 1 });
             }
             if pivot_row != k {
                 for j in 0..n {
@@ -209,6 +207,7 @@ impl<T: Real> Matrix<T> {
             }
             b[i] = sum / a[i * n + i];
         }
+        Ok(())
     }
 }
 

--- a/src/methods/irk/adaptive/ordinary.rs
+++ b/src/methods/irk/adaptive/ordinary.rs
@@ -198,7 +198,7 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
 
             // Solve (I - h*A⊗J) Δz = -F(z) using our LU in-place over a flat slice
             let mut rhs = self.rhs_newton.clone();
-            self.newton_matrix.lin_solve_mut(&mut rhs[..]);
+            self.newton_matrix.lin_solve_mut(&mut rhs[..])?;
             for i in 0..self.delta_k_vec.len() {
                 self.delta_k_vec[i] = rhs[i];
             }

--- a/src/methods/irk/fixed/ordinary.rs
+++ b/src/methods/irk/fixed/ordinary.rs
@@ -176,7 +176,7 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
 
             // Solve (I - h*A⊗J) Δz = -F(z) using in-place LU on our matrix
             let mut rhs = self.rhs_newton.clone();
-            self.newton_matrix.lin_solve_mut(&mut rhs[..]);
+            self.newton_matrix.lin_solve_mut(&mut rhs[..])?;
             for i in 0..self.delta_k_vec.len() {
                 self.delta_k_vec[i] = rhs[i];
             }


### PR DESCRIPTION
🎯 **What:** The `lin_solve_mut` method previously used a `panic!` macro when encountering a singular matrix during LU factorization with partial pivoting. This has been updated to return a `Result<(), LinalgError>`.
⚠️ **Risk:** Panics in core library functions pose a Denial of Service (DoS) risk, as unexpected singular matrices could crash the entire host application without allowing it to gracefully handle or recover from the error.
🛡️ **Solution:** The `panic!` was replaced with `return Err(crate::linalg::LinalgError::Singular { step: k + 1 });`. The function signature of `lin_solve_mut` was updated accordingly. Call sites in the codebase were identified and updated to bubble up the `Result` using the `?` operator. We also made sure `lin_solve` returns the same consistent `LinalgError::Singular` under the hood.

---
*PR created automatically by Jules for task [17877018448584401160](https://jules.google.com/task/17877018448584401160) started by @Ryan-D-Gast*