### PR TITLE
🧹 Remove `allow(dead_code)` attribute from `src/tableau/mod.rs`

### DIFF
--- a/src/tableau/mod.rs
+++ b/src/tableau/mod.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 //! Butcher Tableau
 
 // Explicit Runge-Kutta methods


### PR DESCRIPTION
🎯 **What:** Removed the `#![allow(dead_code)]` attribute from `src/tableau/mod.rs`.
💡 **Why:** To improve code health. Dead code warnings are a valuable tool to find unused and potentially outdated code that should be removed or cleaned up. Removing this attribute enforces correct code hygiene.
✅ **Verification:** Ran `RUSTFLAGS="-D dead_code" cargo check` and verified that no compilation warnings or errors regarding dead code were emitted. Ran `cargo test` to ensure no functionality is broken.
✨ **Result:** The attribute is removed and the project builds warning-free, maintaining codebase hygiene.

---
*PR created automatically by Jules for task [3114548939305700912](https://jules.google.com/task/3114548939305700912) started by @Ryan-D-Gast*