### PR TITLE
🔒 [security fix] Prevent panic in `to_csv` due to unsafe file creation

### DIFF
--- a/src/solution.rs
+++ b/src/solution.rs
@@ -219,8 +219,10 @@ where
     pub fn to_csv(&self, filename: &str) -> Result<(), Box<dyn std::error::Error>> {
         // Create file and path if it does not exist
         let path = std::path::Path::new(filename);
-        if !path.exists() {
-            std::fs::create_dir_all(path.parent().unwrap())?;
+        if let Some(parent) = path.parent() {
+            if !parent.exists() {
+                std::fs::create_dir_all(parent)?;
+            }
         }
         let mut file = std::fs::File::create(filename)?;
 


### PR DESCRIPTION
🎯 **What:** Fixed an unsafe `unwrap()` on `path.parent()` in `src/solution.rs`.
⚠️ **Risk:** The code would panic if `to_csv` was called with a filename that has no parent (like the root directory `/` or an empty string `""`). If this filename is user-controlled, it could lead to a Denial of Service (DoS).
🛡️ **Solution:** Implemented an `if let Some(parent)` pattern to safely check for the existence of a parent directory before attempting to create it.

---
*PR created automatically by Jules for task [15658266244229110070](https://jules.google.com/task/15658266244229110070) started by @Ryan-D-Gast*