### PR TITLE
🧪 Add tests for linear and cubic interpolators

### DIFF
--- a/src/interpolate.rs
+++ b/src/interpolate.rs
@@ -70,3 +70,84 @@ pub fn linear_interpolate<T: Real, Y: State<T>>(t0: T, t1: T, y0: &Y, y1: &Y, t:
     let s = (t - t0) / (t1 - t0);
     *y0 * (T::one() - s) + *y1 * s
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::SMatrix;
+
+    #[test]
+    fn test_linear_interpolate_f64() {
+        let t0 = 0.0;
+        let t1 = 1.0;
+        let y0 = 0.0;
+        let y1 = 2.0;
+
+        // At t0
+        assert!((linear_interpolate(t0, t1, &y0, &y1, t0) - y0).abs() < 1e-10);
+        // At t1
+        assert!((linear_interpolate(t0, t1, &y0, &y1, t1) - y1).abs() < 1e-10);
+        // At midpoint
+        assert!((linear_interpolate(t0, t1, &y0, &y1, 0.5) - 1.0).abs() < 1e-10);
+        // Extrapolation
+        assert!((linear_interpolate(t0, t1, &y0, &y1, 2.0) - 4.0).abs() < 1e-10);
+        assert!((linear_interpolate(t0, t1, &y0, &y1, -1.0) - (-2.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_linear_interpolate_smatrix() {
+        let t0 = 0.0;
+        let t1 = 2.0;
+        let y0 = SMatrix::<f64, 2, 1>::new(1.0, 2.0);
+        let y1 = SMatrix::<f64, 2, 1>::new(3.0, 6.0);
+
+        // At t0
+        let res_t0 = linear_interpolate(t0, t1, &y0, &y1, t0);
+        assert!((res_t0 - y0).norm() < 1e-10);
+        // At t1
+        let res_t1 = linear_interpolate(t0, t1, &y0, &y1, t1);
+        assert!((res_t1 - y1).norm() < 1e-10);
+        // At midpoint (t=1.0)
+        let expected_mid = SMatrix::<f64, 2, 1>::new(2.0, 4.0);
+        let res_mid = linear_interpolate(t0, t1, &y0, &y1, 1.0);
+        assert!((res_mid - expected_mid).norm() < 1e-10);
+    }
+
+    #[test]
+    fn test_cubic_hermite_interpolate_f64() {
+        let t0 = 0.0;
+        let t1 = 1.0;
+        let y0 = 0.0;
+        let y1 = 1.0;
+        let k0 = 0.0;
+        let k1 = 0.0;
+
+        // At t0
+        assert!((cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, t0) - y0).abs() < 1e-10);
+        // At t1
+        assert!((cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, t1) - y1).abs() < 1e-10);
+
+        // At midpoint for y = 3x^2 - 2x^3 (which has y(0)=0, y(1)=1, y'(0)=0, y'(1)=0)
+        // y(0.5) = 3(0.25) - 2(0.125) = 0.75 - 0.25 = 0.5
+        assert!((cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, 0.5) - 0.5).abs() < 1e-10);
+
+        // Test with non-zero derivatives
+        // y = x => y(0)=0, y(1)=1, y'(0)=1, y'(1)=1
+        let k0 = 1.0;
+        let k1 = 1.0;
+        assert!((cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, 0.5) - 0.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_cubic_hermite_interpolate_smatrix() {
+        let t0 = 0.0;
+        let t1 = 1.0;
+        let y0 = SMatrix::<f64, 1, 1>::new(0.0);
+        let y1 = SMatrix::<f64, 1, 1>::new(1.0);
+        let k0 = SMatrix::<f64, 1, 1>::new(1.0);
+        let k1 = SMatrix::<f64, 1, 1>::new(1.0);
+
+        let res = cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, 0.5);
+        assert!((res[(0, 0)] - 0.5).abs() < 1e-10);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap for `linear_interpolate` and `cubic_hermite_interpolate` in `src/interpolate.rs` has been addressed.
📊 **Coverage:** 
- `linear_interpolate`: Boundary conditions, midpoint, and extrapolation (forward/backward) are now tested.
- `cubic_hermite_interpolate`: Boundary conditions and known functional values (including non-zero derivatives) are now tested.
- Both functions are tested with `f64` and `nalgebra::SMatrix` to ensure the `State<T>` trait requirement is correctly handled.
✨ **Result:** Improved reliability and coverage for core interpolation utilities.

---
*PR created automatically by Jules for task [3243335121986995880](https://jules.google.com/task/3243335121986995880) started by @Ryan-D-Gast*