### PR TITLE
🧹 [code health] Tighten scope of unused_variables allows on traits

### DIFF
--- a/src/dae/dae.rs
+++ b/src/dae/dae.rs
@@ -25,7 +25,7 @@ use crate::{
 /// Note that the event function is optional and can be left out when implementing
 /// in which case it will be set to return Continue by default.
 ///
-#[allow(unused_variables)]
+
 pub trait DAE<T = f64, V = f64>
 where
     T: Real,
@@ -80,6 +80,7 @@ where
     /// # Returns
     /// * `ControlFlag` - Command to continue or stop solver.
     ///
+    #[allow(unused_variables)]
     fn event(&self, t: T, y: &V) -> ControlFlag<T, V> {
         ControlFlag::Continue
     }

--- a/src/ode/ode.rs
+++ b/src/ode/ode.rs
@@ -22,7 +22,7 @@ use crate::{
 ///
 /// Note that the event and jacobian functions are optional and can be left out when implementing.
 ///
-#[allow(unused_variables)]
+
 pub trait ODE<T = f64, Y = f64>
 where
     T: Real,

--- a/src/sde/sde.rs
+++ b/src/sde/sde.rs
@@ -20,7 +20,7 @@ use crate::traits::{Real, State};
 ///
 /// Note that the event function is optional and can be left out when implementing.
 ///
-#[allow(unused_variables)]
+
 pub trait SDE<T = f64, Y = f64>
 where
     T: Real,


### PR DESCRIPTION
🎯 **What:** Removed `#[allow(unused_variables)]` from `DAE`, `ODE`, and `SDE` traits, moving it exclusively to the `DAE::event` default implementation.
💡 **Why:** Applying `#[allow(unused_variables)]` at the trait level hides unused variables warnings globally for everything within the trait. Scoping it down strictly to the specific function that needs it is standard practice and prevents accidentally burying unrelated warnings.
✅ **Verification:** Verified by running `cargo test --lib` and checking for warnings using `cargo clippy`.
✨ **Result:** Improved maintainability by tightening the scope of ignored warnings without changing variable names in the trait definitions.

---
*PR created automatically by Jules for task [5802931019214233224](https://jules.google.com/task/5802931019214233224) started by @Ryan-D-Gast*