### PR TITLE
⚡ Remove redundant clone in problem edge cases tests

### DIFF
--- a/derive/tests/edge_cases.rs
+++ b/derive/tests/edge_cases.rs
@@ -53,7 +53,7 @@ fn test_clone_and_copy() {
     }
 
     let original = CloneTest { x: 1.0, arr: [2.0, 3.0] };
-    let cloned = original.clone();
+    let cloned = original;
     let copied = original;
 
     assert_eq!(original, cloned);


### PR DESCRIPTION
💡 **What:** Removed a redundant `.clone()` call in `derive/tests/edge_cases.rs`.
🎯 **Why:** The variable being cloned already implements the `Copy` trait as part of the `State` derive macro's generated code, meaning an explicit `.clone()` isn't necessary. Removing it resolves the `clippy::clone_on_copy` lint warning and is a good habit for avoiding unnecessary function calls.
📊 **Measured Improvement:** As this is purely a minor modification within a test file, measuring the real-world performance impact is impractical and inherently negligible. No benchmark suite improvements are observable. However, this change prevents a redundant function invocation and cleans up a Clippy warning, resulting in better overall code hygiene.

---
*PR created automatically by Jules for task [2521086439145969268](https://jules.google.com/task/2521086439145969268) started by @Ryan-D-Gast*