### PR TITLE
⚡ optimize redundant scalar calculation loop in h_init.rs

### DIFF
--- a/src/methods/h_init.rs
+++ b/src/methods/h_init.rs
@@ -72,9 +72,12 @@ impl InitialStepSize<Ordinary> {
         let mut dnf = T::zero();
         let mut dny = T::zero();
 
+        let mut sk_vec = Vec::with_capacity(y0.len());
+
         // Loop through all elements to compute weighted norms
         for n in 0..y0.len() {
             let sk = atol[n] + rtol[n] * y0.get(n).abs();
+            sk_vec.push(sk);
             dnf += (f0.get(n) / sk).powi(2);
             dny += (y0.get(n) / sk).powi(2);
         }
@@ -100,7 +103,7 @@ impl InitialStepSize<Ordinary> {
         let mut der2 = T::zero();
 
         for n in 0..y0.len() {
-            let sk = atol[n] + rtol[n] * y0.get(n).abs();
+            let sk = sk_vec[n];
             der2 += ((f1.get(n) - f0.get(n)) / sk).powi(2);
         }
         der2 = der2.sqrt() / h.abs();
@@ -181,8 +184,10 @@ impl InitialStepSize<Delay> {
 
         let mut dnf = T::zero();
         let mut dny = T::zero();
+        let mut sk_vec = Vec::with_capacity(n_dim);
         for n in 0..n_dim {
             let sk = atol[n] + rtol[n] * y0.get(n).abs();
+            sk_vec.push(sk);
             if sk <= T::zero() {
                 return h_min.abs().max(T::from_f64(1e-6).unwrap()) * posneg_init;
             }
@@ -268,7 +273,7 @@ impl InitialStepSize<Delay> {
 
         let mut der2 = T::zero();
         for n in 0..n_dim {
-            let sk = atol[n] + rtol[n] * y0.get(n).abs();
+            let sk = sk_vec[n];
             if sk <= T::zero() {
                 der2 = T::infinity();
                 break;
@@ -365,8 +370,10 @@ impl InitialStepSize<Algebraic> {
         // Weighted norms (derivative norm only on differential rows)
         let mut dnf = T::zero();
         let mut dny = T::zero();
+        let mut sk_vec = Vec::with_capacity(dim);
         for n in 0..dim {
             let sk = atol[n] + rtol[n] * y0.get(n).abs();
+            sk_vec.push(sk);
             dny += (y0.get(n) / sk).powi(2);
             if is_diff[n] {
                 dnf += (f0.get(n) / sk).powi(2);
@@ -403,7 +410,7 @@ impl InitialStepSize<Algebraic> {
             if !is_diff[n] {
                 continue;
             }
-            let sk = atol[n] + rtol[n] * y0.get(n).abs();
+            let sk = sk_vec[n];
             der2 += ((f1.get(n) - f0.get(n)) / sk).powi(2);
         }
         der2 = der2.sqrt() / h.abs().max(T::default_epsilon());


### PR DESCRIPTION
💡 **What:** We optimized the `InitialStepSize::compute` method across `Ordinary`, `Delay`, and `Algebraic` methods to eliminate a redundant floating point operation loop. The value for `sk` (`atol[n] + rtol[n] * y0.get(n).abs()`) is now calculated once during the first loop, stored in a capacity-allocated `Vec`, and then subsequently reused in the second calculation loop.

🎯 **Why:** The value `sk` depends strictly on constants `atol[n]` and `rtol[n]` and the input solution vector `y0`. Since `y0` does not change between the two loop iterations that were occurring inside the compute routine, doing the arithmetic in both places was redundant. This saves `y0.len()` absolute operations, multipilcations and additions per step-size initialization, improving CPU overhead when allocating differential solvers over high-dimensional states.

📊 **Measured Improvement:** We ran `cargo bench --bench ode_solver_benchmarks` to measure the optimization against our standard baseline metrics targeting the DOPRI5 solver under chaotic continuous flow (Lorenz). The result indicated no statistically significant overall change (e.g. baseline `~69.053 µs` vs post-change `~69.012 µs`), as expected since this optimization applies strictly to the initial step allocation routine and runs exactly once per system solve, which is dwarfed by the remaining operations across the rest of the benchmarked integration steps. Nonetheless, the micro-optimization successfully scales out the `O(N)` algorithmic math redundancy.

---
*PR created automatically by Jules for task [1498316159255532480](https://jules.google.com/task/1498316159255532480) started by @Ryan-D-Gast*