### PR TITLE
⚡ Optimize Solution::new to avoid redundant allocations

### DIFF
--- a/src/solution.rs
+++ b/src/solution.rs
@@ -67,8 +67,23 @@ where
     /// Creates a new Solution object.
     pub fn new() -> Self {
         Solution {
-            t: Vec::with_capacity(100),
-            y: Vec::with_capacity(100),
+            t: Vec::new(),
+            y: Vec::new(),
+            status: Status::Uninitialized,
+            evals: Evals::new(),
+            steps: Steps::new(),
+            timer: Timer::Off,
+        }
+    }
+
+    /// Creates a new Solution object with pre-allocated capacity for points.
+    ///
+    /// # Arguments
+    /// * `capacity` - Initial capacity for the vectors holding time and state points.
+    pub fn new_with_capacity(capacity: usize) -> Self {
+        Solution {
+            t: Vec::with_capacity(capacity),
+            y: Vec::with_capacity(capacity),
             status: Status::Uninitialized,
             evals: Evals::new(),
             steps: Steps::new(),


### PR DESCRIPTION
💡 **What:** Modified `Solution::new()` to initialize `t` and `y` using `Vec::new()` instead of `Vec::with_capacity(100)`. Added a new function `Solution::new_with_capacity(capacity: usize)` that uses `Vec::with_capacity(capacity)`.

🎯 **Why:** Unconditional allocation of 100 elements is arbitrary and wastes memory for solutions that require fewer points. This change avoids redundant allocations while offering callers a way to efficiently pre-allocate capacity if the expected output size is known.

📊 **Measured Improvement:** The benchmarks showed slight regression/improvements across different solvers, but generally well within the noise threshold (changes like ~ -1.5% to +1.6%). The true benefit is reduced memory fragmentation and baseline memory allocations since some ODE solver runs may be small or immediately overwrite this.

---
*PR created automatically by Jules for task [11644347193013844735](https://jules.google.com/task/11644347193013844735) started by @Ryan-D-Gast*