### PR TITLE
🧹 Remove temporary script `patch_complex_test.sh`

### DIFF
--- a/patch_complex_test.sh
+++ b/patch_complex_test.sh
@@ -1,1 +1,0 @@
-sed -i 's/state.set(2, 3.0);/state.set(2, 3.0);/' src/traits.rs


### PR DESCRIPTION
What: Removed `patch_complex_test.sh` from the repository and verified no other temporary files were left behind.

Why: The shell script was temporary for testing or patching purposes and is no longer required in the main repository.

Verification: Executed a search for temporary files and verified the tests still pass.

Result: A cleaner repository without unnecessary temporary scripts.

---
*PR created automatically by Jules for task [8687588178715176397](https://jules.google.com/task/8687588178715176397) started by @Ryan-D-Gast*