### PR TITLE
🧪 Consolidate unit tests to reduce clutter

### DIFF
--- a/src/interpolate.rs
+++ b/src/interpolate.rs
@@ -79,7 +79,8 @@ mod tests {
     use nalgebra::SMatrix;
 
     #[test]
-    fn test_linear_interpolate_f64() {
+    fn test_linear_interpolate() {
+        // test f64
         let t0 = 0.0_f64;
         let t1 = 1.0_f64;
         let y0 = 0.0_f64;
@@ -90,10 +91,8 @@ mod tests {
         assert!((linear_interpolate(t0, t1, &y0, &y1, 0.5_f64) - 1.0_f64).abs() < 1e-10);
         assert!((linear_interpolate(t0, t1, &y0, &y1, 2.0_f64) - 4.0_f64).abs() < 1e-10);
         assert!((linear_interpolate(t0, t1, &y0, &y1, -1.0_f64) - (-2.0_f64)).abs() < 1e-10);
-    }
 
-    #[test]
-    fn test_linear_interpolate_smatrix() {
+        // test smatrix
         let t0 = 0.0;
         let t1 = 2.0;
         let y0 = SMatrix::<f64, 2, 1>::new(1.0, 2.0);
@@ -111,92 +110,91 @@ mod tests {
     }
 
     #[test]
-    fn test_cubic_hermite_interpolate_bounds() {
-        let t0 = 0.0;
-        let t1 = 1.0;
-        let y0 = 2.5;
-        let y1 = -1.5;
-        let k0 = 1.0;
-        let k1 = -0.5;
+    fn test_cubic_hermite_interpolate() {
+        {
+            let t0 = 0.0;
+            let t1 = 1.0;
+            let y0 = 2.5;
+            let y1 = -1.5;
+            let k0 = 1.0;
+            let k1 = -0.5;
 
-        // At t0, should evaluate exactly to y0
-        let res0 = cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, t0);
-        assert_eq!(res0, y0);
+            // At t0, should evaluate exactly to y0
+            let res0 = cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, t0);
+            assert_eq!(res0, y0);
 
-        // At t1, should evaluate exactly to y1
-        let res1 = cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, t1);
-        assert_eq!(res1, y1);
-    }
+            // At t1, should evaluate exactly to y1
+            let res1 = cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, t1);
+            assert_eq!(res1, y1);
+        }
 
-    #[test]
-    fn test_cubic_hermite_interpolate_analytical() {
-        // Test exact reproduction of a cubic polynomial f(t) = t^3.
-        // f(t) = t^3
-        // f'(t) = 3t^2
-        let t0 = 1.0;
-        let t1 = 2.0;
-        let y0 = 1.0; // 1^3
-        let y1 = 8.0; // 2^3
-        let k0 = 3.0; // 3 * 1^2
-        let k1 = 12.0; // 3 * 2^2
+        {
+            // Test exact reproduction of a cubic polynomial f(t) = t^3.
+            // f(t) = t^3
+            // f'(t) = 3t^2
+            let t0 = 1.0;
+            let t1 = 2.0;
+            let y0 = 1.0; // 1^3
+            let y1 = 8.0; // 2^3
+            let k0 = 3.0; // 3 * 1^2
+            let k1 = 12.0; // 3 * 2^2
 
-        let t_mid = 1.5;
-        let expected_mid = 3.375; // 1.5^3
+            let t_mid = 1.5;
+            let expected_mid = 3.375; // 1.5^3
 
-        let res_mid: f64 = cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, t_mid);
-        assert!(
-            (res_mid - expected_mid).abs() < 1e-12,
-            "Expected {}, got {}",
-            expected_mid,
-            res_mid
-        );
+            let res_mid: f64 = cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, t_mid);
+            assert!(
+                (res_mid - expected_mid).abs() < 1e-12,
+                "Expected {}, got {}",
+                expected_mid,
+                res_mid
+            );
 
-        let t_quarter = 1.25;
-        let expected_quarter = 1.953125; // 1.25^3
+            let t_quarter = 1.25;
+            let expected_quarter = 1.953125; // 1.25^3
 
-        let res_quarter: f64 = cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, t_quarter);
-        assert!(
-            (res_quarter - expected_quarter).abs() < 1e-12,
-            "Expected {}, got {}",
-            expected_quarter,
-            res_quarter
-        );
-    }
+            let res_quarter: f64 = cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, t_quarter);
+            assert!(
+                (res_quarter - expected_quarter).abs() < 1e-12,
+                "Expected {}, got {}",
+                expected_quarter,
+                res_quarter
+            );
+        }
 
-    #[test]
-    fn test_cubic_hermite_interpolate_f64() {
-        let t0 = 0.0_f64;
-        let t1 = 1.0_f64;
-        let y0 = 0.0_f64;
-        let y1 = 1.0_f64;
-        let k0 = 0.0_f64;
-        let k1 = 0.0_f64;
+        {
+            let t0 = 0.0_f64;
+            let t1 = 1.0_f64;
+            let y0 = 0.0_f64;
+            let y1 = 1.0_f64;
+            let k0 = 0.0_f64;
+            let k1 = 0.0_f64;
 
-        assert!((cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, t0) - y0).abs() < 1e-10);
-        assert!((cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, t1) - y1).abs() < 1e-10);
-        assert!(
-            (cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, 0.5_f64) - 0.5_f64).abs()
-                < 1e-10
-        );
+            assert!((cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, t0) - y0).abs() < 1e-10);
+            assert!((cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, t1) - y1).abs() < 1e-10);
+            assert!(
+                (cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, 0.5_f64) - 0.5_f64).abs()
+                    < 1e-10
+            );
 
-        let k0 = 1.0_f64;
-        let k1 = 1.0_f64;
-        assert!(
-            (cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, 0.5_f64) - 0.5_f64).abs()
-                < 1e-10
-        );
-    }
+            let k0 = 1.0_f64;
+            let k1 = 1.0_f64;
+            assert!(
+                (cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, 0.5_f64) - 0.5_f64).abs()
+                    < 1e-10
+            );
+        }
 
-    #[test]
-    fn test_cubic_hermite_interpolate_smatrix() {
-        let t0 = 0.0;
-        let t1 = 1.0;
-        let y0 = SMatrix::<f64, 1, 1>::new(0.0);
-        let y1 = SMatrix::<f64, 1, 1>::new(1.0);
-        let k0 = SMatrix::<f64, 1, 1>::new(1.0);
-        let k1 = SMatrix::<f64, 1, 1>::new(1.0);
+        {
+            let t0 = 0.0;
+            let t1 = 1.0;
+            let y0 = SMatrix::<f64, 1, 1>::new(0.0);
+            let y1 = SMatrix::<f64, 1, 1>::new(1.0);
+            let k0 = SMatrix::<f64, 1, 1>::new(1.0);
+            let k1 = SMatrix::<f64, 1, 1>::new(1.0);
 
-        let res = cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, 0.5);
-        assert!((res[(0, 0)] - 0.5).abs() < 1e-10);
+            let res = cubic_hermite_interpolate(t0, t1, &y0, &y1, &k0, &k1, 0.5);
+            assert!((res[(0, 0)] - 0.5).abs() < 1e-10);
+        }
     }
 }

--- a/src/linalg/lu.rs
+++ b/src/linalg/lu.rs
@@ -343,101 +343,99 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_dec_simple() {
-        // Test LU decomposition of a simple 2x2 matrix
-        let mut a = Matrix::from_vec(2, 2, vec![2.0_f64, 1.0, 4.0, 3.0]);
-        let mut ip = [0; 2];
+    fn test_dec() {
+        {
+            // Test LU decomposition of a simple 2x2 matrix
+            let mut a = Matrix::from_vec(2, 2, vec![2.0_f64, 1.0, 4.0, 3.0]);
+            let mut ip = [0; 2];
 
-        let result = lu_decomp(&mut a, &mut ip);
-        assert!(result.is_ok());
+            let result = lu_decomp(&mut a, &mut ip);
+            assert!(result.is_ok());
 
-        // The matrix should be factorized in-place
-        // We can verify that the diagonal elements are non-zero
-        assert!(a[(0, 0)].abs() > 1e-10);
-        assert!(a[(1, 1)].abs() > 1e-10);
+            // The matrix should be factorized in-place
+            // We can verify that the diagonal elements are non-zero
+            assert!(a[(0, 0)].abs() > 1e-10);
+            assert!(a[(1, 1)].abs() > 1e-10);
+        }
+
+        {
+            // Test with a singular matrix
+            let mut a = Matrix::from_vec(2, 2, vec![1.0_f64, 0.0, 0.0, 0.0]);
+            let mut ip = [0; 2];
+
+            let result = lu_decomp(&mut a, &mut ip);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err(), LinalgError::Singular { step: 2 });
+        }
+
+        {
+            // Test with a 1x1 matrix
+            let mut a = Matrix::from_vec(1, 1, vec![5.0_f64]);
+            let mut ip = [0; 1];
+
+            let result = lu_decomp(&mut a, &mut ip);
+            assert!(result.is_ok());
+            assert_eq!(ip[0], 0);
+        }
+
+        {
+            // Test with a singular 1x1 matrix
+            let mut a = Matrix::from_vec(1, 1, vec![0.0_f64]);
+            let mut ip = [0; 1];
+
+            let result = lu_decomp(&mut a, &mut ip);
+            assert!(result.is_err());
+            assert_eq!(result.unwrap_err(), LinalgError::Singular { step: 1 });
+        }
     }
 
     #[test]
-    fn test_dec_singular() {
-        // Test with a singular matrix
-        let mut a = Matrix::from_vec(2, 2, vec![1.0_f64, 0.0, 0.0, 0.0]);
-        let mut ip = [0; 2];
+    fn test_decc() {
+        {
+            // Test complex LU decomposition of a simple 2x2 matrix
+            let mut ar = Matrix::from_vec(2, 2, vec![1.0_f64, 0.0, 0.0, 1.0]);
+            let mut ai = Matrix::from_vec(2, 2, vec![0.0, 1.0, 1.0, 0.0]);
+            let mut ip = [0; 2];
 
-        let result = lu_decomp(&mut a, &mut ip);
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), LinalgError::Singular { step: 2 });
-    }
+            let result = lu_decomp_complex(&mut ar, &mut ai, &mut ip);
+            assert!(result.is_ok());
 
-    #[test]
-    fn test_dec_1x1() {
-        // Test with a 1x1 matrix
-        let mut a = Matrix::from_vec(1, 1, vec![5.0_f64]);
-        let mut ip = [0; 1];
+            // Verify that the diagonal elements have non-zero magnitude
+            let diag0_mag = ar[(0, 0)].abs() + ai[(0, 0)].abs();
+            let diag1_mag = ar[(1, 1)].abs() + ai[(1, 1)].abs();
+            assert!(diag0_mag > 1e-10);
+            assert!(diag1_mag > 1e-10);
+        }
 
-        let result = lu_decomp(&mut a, &mut ip);
-        assert!(result.is_ok());
-        assert_eq!(ip[0], 0);
-    }
+        {
+            // Test with a singular complex matrix
+            let mut ar = Matrix::from_vec(2, 2, vec![1.0_f64, 1.0, 1.0, 1.0]);
+            let mut ai = Matrix::from_vec(2, 2, vec![0.0_f64, 0.0, 0.0, 0.0]);
+            let mut ip = [0; 2];
 
-    #[test]
-    fn test_dec_1x1_singular() {
-        // Test with a singular 1x1 matrix
-        let mut a = Matrix::from_vec(1, 1, vec![0.0_f64]);
-        let mut ip = [0; 1];
+            let result = lu_decomp_complex(&mut ar, &mut ai, &mut ip);
+            assert!(result.is_err());
+        }
 
-        let result = lu_decomp(&mut a, &mut ip);
-        assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), LinalgError::Singular { step: 1 });
-    }
+        {
+            // Test with a 1x1 complex matrix
+            let mut ar = Matrix::from_vec(1, 1, vec![3.0_f64]);
+            let mut ai = Matrix::from_vec(1, 1, vec![4.0_f64]); // 3 + 4i
+            let mut ip = [0; 1];
 
-    #[test]
-    fn test_decc_simple() {
-        // Test complex LU decomposition of a simple 2x2 matrix
-        let mut ar = Matrix::from_vec(2, 2, vec![1.0_f64, 0.0, 0.0, 1.0]);
-        let mut ai = Matrix::from_vec(2, 2, vec![0.0, 1.0, 1.0, 0.0]);
-        let mut ip = [0; 2];
+            let result = lu_decomp_complex(&mut ar, &mut ai, &mut ip);
+            assert!(result.is_ok());
+            assert_eq!(ip[0], 0);
+        }
 
-        let result = lu_decomp_complex(&mut ar, &mut ai, &mut ip);
-        assert!(result.is_ok());
+        {
+            // Test with a singular 1x1 complex matrix
+            let mut ar = Matrix::from_vec(1, 1, vec![0.0_f64]);
+            let mut ai = Matrix::from_vec(1, 1, vec![0.0_f64]);
+            let mut ip = [0; 1];
 
-        // Verify that the diagonal elements have non-zero magnitude
-        let diag0_mag = ar[(0, 0)].abs() + ai[(0, 0)].abs();
-        let diag1_mag = ar[(1, 1)].abs() + ai[(1, 1)].abs();
-        assert!(diag0_mag > 1e-10);
-        assert!(diag1_mag > 1e-10);
-    }
-
-    #[test]
-    fn test_decc_singular() {
-        // Test with a singular complex matrix
-        let mut ar = Matrix::from_vec(2, 2, vec![1.0_f64, 1.0, 1.0, 1.0]);
-        let mut ai = Matrix::from_vec(2, 2, vec![0.0_f64, 0.0, 0.0, 0.0]);
-        let mut ip = [0; 2];
-
-        let result = lu_decomp_complex(&mut ar, &mut ai, &mut ip);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_decc_1x1() {
-        // Test with a 1x1 complex matrix
-        let mut ar = Matrix::from_vec(1, 1, vec![3.0_f64]);
-        let mut ai = Matrix::from_vec(1, 1, vec![4.0_f64]); // 3 + 4i
-        let mut ip = [0; 1];
-
-        let result = lu_decomp_complex(&mut ar, &mut ai, &mut ip);
-        assert!(result.is_ok());
-        assert_eq!(ip[0], 0);
-    }
-
-    #[test]
-    fn test_decc_1x1_singular() {
-        // Test with a singular 1x1 complex matrix
-        let mut ar = Matrix::from_vec(1, 1, vec![0.0_f64]);
-        let mut ai = Matrix::from_vec(1, 1, vec![0.0_f64]);
-        let mut ip = [0; 1];
-
-        let result = lu_decomp_complex(&mut ar, &mut ai, &mut ip);
-        assert!(result.is_err());
+            let result = lu_decomp_complex(&mut ar, &mut ai, &mut ip);
+            assert!(result.is_err());
+        }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -177,31 +177,28 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_step_size_parameters_valid() {
+    fn test_validate_step_size_parameters() {
+        // test valid positive direction
         let result: Result<f64, Error<f64, f64>> =
             validate_step_size_parameters(0.1, 0.01, 1.0, 0.0, 10.0);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), 0.1);
 
+        // test valid negative direction
         let result_negative: Result<f64, Error<f64, f64>> =
             validate_step_size_parameters(-0.1, 0.01, 1.0, 10.0, 0.0);
         assert!(result_negative.is_ok());
         assert_eq!(result_negative.unwrap(), -0.1);
-    }
 
-    #[test]
-    fn test_validate_step_size_parameters_tf_equals_t0() {
+        // test tf equals t0
         let result: Result<f64, Error<f64, f64>> =
             validate_step_size_parameters(0.1, 0.01, 1.0, 5.0, 5.0);
         assert!(matches!(result, Err(Error::BadInput { .. })));
         if let Err(Error::BadInput { msg }) = result {
             assert!(msg.contains("cannot be equal to t0"));
         }
-    }
 
-    #[test]
-    fn test_validate_step_size_parameters_wrong_sign() {
-        // tf - t0 is positive, but h0 is negative
+        // test wrong sign positive tf-t0
         let result: Result<f64, Error<f64, f64>> =
             validate_step_size_parameters(-0.1, 0.01, 1.0, 0.0, 10.0);
         assert!(matches!(result, Err(Error::BadInput { .. })));
@@ -209,15 +206,12 @@ mod tests {
             assert!(msg.contains("same sign as the integration direction"));
         }
 
-        // tf - t0 is negative, but h0 is positive
+        // test wrong sign negative tf-t0
         let result_negative: Result<f64, Error<f64, f64>> =
             validate_step_size_parameters(0.1, 0.01, 1.0, 10.0, 0.0);
         assert!(matches!(result_negative, Err(Error::BadInput { .. })));
-    }
 
-    #[test]
-    fn test_validate_step_size_parameters_negative_bounds() {
-        // h_min negative
+        // test h_min negative
         let result1: Result<f64, Error<f64, f64>> =
             validate_step_size_parameters(0.1, -0.01, 1.0, 0.0, 10.0);
         assert!(matches!(result1, Err(Error::BadInput { .. })));
@@ -226,7 +220,7 @@ mod tests {
             assert!(msg.contains("non-negative"));
         }
 
-        // h_max negative
+        // test h_max negative
         let result2: Result<f64, Error<f64, f64>> =
             validate_step_size_parameters(0.1, 0.01, -1.0, 0.0, 10.0);
         assert!(matches!(result2, Err(Error::BadInput { .. })));
@@ -234,21 +228,16 @@ mod tests {
             assert!(msg.contains("Maximum step size"));
             assert!(msg.contains("non-negative"));
         }
-    }
 
-    #[test]
-    fn test_validate_step_size_parameters_min_greater_than_max() {
+        // test min greater than max
         let result: Result<f64, Error<f64, f64>> =
             validate_step_size_parameters(0.5, 1.0, 0.1, 0.0, 10.0);
         assert!(matches!(result, Err(Error::BadInput { .. })));
         if let Err(Error::BadInput { msg }) = result {
             assert!(msg.contains("less than or equal to maximum step size"));
         }
-    }
 
-    #[test]
-    fn test_validate_step_size_parameters_h0_out_of_bounds() {
-        // |h0| < h_min
+        // test |h0| < h_min
         let result1: Result<f64, Error<f64, f64>> =
             validate_step_size_parameters(0.001, 0.01, 1.0, 0.0, 10.0);
         assert!(matches!(result1, Err(Error::BadInput { .. })));
@@ -256,7 +245,7 @@ mod tests {
             assert!(msg.contains("greater than or equal to minimum step size"));
         }
 
-        // |h0| > h_max
+        // test |h0| > h_max
         let result2: Result<f64, Error<f64, f64>> =
             validate_step_size_parameters(2.0, 0.01, 1.0, 0.0, 10.0);
         assert!(matches!(result2, Err(Error::BadInput { .. })));
@@ -264,7 +253,7 @@ mod tests {
             assert!(msg.contains("less than or equal to maximum step size"));
         }
 
-        // |h0| > |tf - t0|
+        // test |h0| > |tf - t0|
         let result3: Result<f64, Error<f64, f64>> =
             validate_step_size_parameters(0.5, 0.01, 1.0, 0.0, 0.2);
         assert!(matches!(result3, Err(Error::BadInput { .. })));
@@ -275,10 +264,8 @@ mod tests {
                 )
             );
         }
-    }
 
-    #[test]
-    fn test_validate_step_size_parameters_h0_zero() {
+        // test h0 zero
         let result: Result<f64, Error<f64, f64>> =
             validate_step_size_parameters(0.0, 0.0, 1.0, 0.0, 10.0);
         assert!(matches!(result, Err(Error::BadInput { .. })));


### PR DESCRIPTION
🎯 What
Consolidated redundant and repetitive unit tests within `src/interpolate.rs`, `src/linalg/lu.rs`, and `src/utils.rs` into single, well-structured test functions that verify the exact same logic.

📊 Coverage
No coverage was lost. We preserved all test assertions, simply grouping them into logically related blocks to keep the test suite cleaner and easier to maintain. 

✨ Result
A significantly less cluttered test suite that tests components separate from solvers, making it easier to read and extend.

---
*PR created automatically by Jules for task [4999041626971472531](https://jules.google.com/task/4999041626971472531) started by @Ryan-D-Gast*