### PR TITLE
refactor(linalg): return Result from Matrix::from_vec

### DIFF
--- a/src/linalg/lu.rs
+++ b/src/linalg/lu.rs
@@ -53,7 +53,7 @@ use crate::{
 /// ```rust,ignore
 /// use differential_equations::linalg::{Matrix, lu::lu_decomp};
 ///
-/// let mut a = Matrix::from_vec(2, 2, vec![2.0, 1.0, 1.0, 1.0]);
+/// let mut a = Matrix::from_vec(2, 2, vec![2.0, 1.0, 1.0, 1.0]).unwrap();
 /// let mut ip = [0; 2];
 ///
 /// match lu_decomp(&mut a, &mut ip) {
@@ -191,8 +191,8 @@ pub fn lu_decomp<T: Real>(a: &mut Matrix<T>, ip: &mut [usize]) -> Result<(), Lin
 /// ```rust,ignore
 /// use differential_equations::linalg::{Matrix, lu_decomp_complex};
 ///
-/// let mut ar = Matrix::from_vec(2, 2, vec![1.0, 0.0, 0.0, 1.0]);
-/// let mut ai = Matrix::from_vec(2, 2, vec![0.0, 1.0, 1.0, 0.0]);
+/// let mut ar = Matrix::from_vec(2, 2, vec![1.0, 0.0, 0.0, 1.0]).unwrap();
+/// let mut ai = Matrix::from_vec(2, 2, vec![0.0, 1.0, 1.0, 0.0]).unwrap();
 /// let mut ip = [0; 2];
 ///
 /// match lu_decomp_complex(&mut ar, &mut ai, &mut ip) {
@@ -345,7 +345,7 @@ mod tests {
     #[test]
     fn test_dec_simple() {
         // Test LU decomposition of a simple 2x2 matrix
-        let mut a = Matrix::from_vec(2, 2, vec![2.0_f64, 1.0, 4.0, 3.0]);
+        let mut a = Matrix::from_vec(2, 2, vec![2.0_f64, 1.0, 4.0, 3.0]).unwrap();
         let mut ip = [0; 2];
 
         let result = lu_decomp(&mut a, &mut ip);
@@ -360,7 +360,7 @@ mod tests {
     #[test]
     fn test_dec_singular() {
         // Test with a singular matrix
-        let mut a = Matrix::from_vec(2, 2, vec![1.0_f64, 0.0, 0.0, 0.0]);
+        let mut a = Matrix::from_vec(2, 2, vec![1.0_f64, 0.0, 0.0, 0.0]).unwrap();
         let mut ip = [0; 2];
 
         let result = lu_decomp(&mut a, &mut ip);
@@ -371,7 +371,7 @@ mod tests {
     #[test]
     fn test_dec_1x1() {
         // Test with a 1x1 matrix
-        let mut a = Matrix::from_vec(1, 1, vec![5.0_f64]);
+        let mut a = Matrix::from_vec(1, 1, vec![5.0_f64]).unwrap();
         let mut ip = [0; 1];
 
         let result = lu_decomp(&mut a, &mut ip);
@@ -382,7 +382,7 @@ mod tests {
     #[test]
     fn test_dec_1x1_singular() {
         // Test with a singular 1x1 matrix
-        let mut a = Matrix::from_vec(1, 1, vec![0.0_f64]);
+        let mut a = Matrix::from_vec(1, 1, vec![0.0_f64]).unwrap();
         let mut ip = [0; 1];
 
         let result = lu_decomp(&mut a, &mut ip);
@@ -393,8 +393,8 @@ mod tests {
     #[test]
     fn test_decc_simple() {
         // Test complex LU decomposition of a simple 2x2 matrix
-        let mut ar = Matrix::from_vec(2, 2, vec![1.0_f64, 0.0, 0.0, 1.0]);
-        let mut ai = Matrix::from_vec(2, 2, vec![0.0, 1.0, 1.0, 0.0]);
+        let mut ar = Matrix::from_vec(2, 2, vec![1.0_f64, 0.0, 0.0, 1.0]).unwrap();
+        let mut ai = Matrix::from_vec(2, 2, vec![0.0, 1.0, 1.0, 0.0]).unwrap();
         let mut ip = [0; 2];
 
         let result = lu_decomp_complex(&mut ar, &mut ai, &mut ip);
@@ -410,8 +410,8 @@ mod tests {
     #[test]
     fn test_decc_singular() {
         // Test with a singular complex matrix
-        let mut ar = Matrix::from_vec(2, 2, vec![1.0_f64, 1.0, 1.0, 1.0]);
-        let mut ai = Matrix::from_vec(2, 2, vec![0.0_f64, 0.0, 0.0, 0.0]);
+        let mut ar = Matrix::from_vec(2, 2, vec![1.0_f64, 1.0, 1.0, 1.0]).unwrap();
+        let mut ai = Matrix::from_vec(2, 2, vec![0.0_f64, 0.0, 0.0, 0.0]).unwrap();
         let mut ip = [0; 2];
 
         let result = lu_decomp_complex(&mut ar, &mut ai, &mut ip);
@@ -421,8 +421,8 @@ mod tests {
     #[test]
     fn test_decc_1x1() {
         // Test with a 1x1 complex matrix
-        let mut ar = Matrix::from_vec(1, 1, vec![3.0_f64]);
-        let mut ai = Matrix::from_vec(1, 1, vec![4.0_f64]); // 3 + 4i
+        let mut ar = Matrix::from_vec(1, 1, vec![3.0_f64]).unwrap();
+        let mut ai = Matrix::from_vec(1, 1, vec![4.0_f64]).unwrap(); // 3 + 4i
         let mut ip = [0; 1];
 
         let result = lu_decomp_complex(&mut ar, &mut ai, &mut ip);
@@ -433,8 +433,8 @@ mod tests {
     #[test]
     fn test_decc_1x1_singular() {
         // Test with a singular 1x1 complex matrix
-        let mut ar = Matrix::from_vec(1, 1, vec![0.0_f64]);
-        let mut ai = Matrix::from_vec(1, 1, vec![0.0_f64]);
+        let mut ar = Matrix::from_vec(1, 1, vec![0.0_f64]).unwrap();
+        let mut ai = Matrix::from_vec(1, 1, vec![0.0_f64]).unwrap();
         let mut ip = [0; 1];
 
         let result = lu_decomp_complex(&mut ar, &mut ai, &mut ip);

--- a/src/linalg/matrix/base.rs
+++ b/src/linalg/matrix/base.rs
@@ -69,15 +69,26 @@ impl<T: Real> Matrix<T> {
         }
     }
 
-    /// Creates a matrix from a vector.
-    pub fn from_vec(n: usize, m: usize, data: Vec<T>) -> Self {
-        assert_eq!(data.len(), n * m, "Incompatible data length");
-        Matrix {
+    /// Creates a dense row-major matrix from a vector.
+    ///
+    /// # Errors
+    /// Returns [`crate::linalg::LinalgError::BadInput`] when `data.len() != n * m`.
+    pub fn from_vec(n: usize, m: usize, data: Vec<T>) -> Result<Self, crate::linalg::LinalgError> {
+        if data.len() != n * m {
+            return Err(crate::linalg::LinalgError::BadInput {
+                message: format!(
+                    "Incompatible data length: expected {}, got {}",
+                    n * m,
+                    data.len()
+                ),
+            });
+        }
+        Ok(Matrix {
             n,
             m,
             data,
             storage: MatrixStorage::Full,
-        }
+        })
     }
 
     /// Empty sparse matrix of size n x m.
@@ -373,6 +384,18 @@ mod tests {
         let u: Matrix<f64> = Matrix::upper_triangular(4);
         // Below main diagonal reads zero
         assert_eq!(u[(3, 0)], 0.0);
+    }
+
+    #[test]
+    fn from_vec_rejects_incompatible_data_length() {
+        let result = Matrix::<f64>::from_vec(2, 3, vec![1.0, 2.0, 3.0, 4.0]);
+
+        assert_eq!(
+            result,
+            Err(crate::linalg::LinalgError::BadInput {
+                message: "Incompatible data length: expected 6, got 4".to_string(),
+            })
+        );
     }
 
     #[test]

--- a/src/linalg/matrix/macros.rs
+++ b/src/linalg/matrix/macros.rs
@@ -24,7 +24,7 @@ macro_rules! matrix {
         assert!(rows_vec.iter().all(|r| r.len() == n), "matrix! requires a square n x n list of rows");
         let mut data = Vec::with_capacity(n*n);
         for r in rows_vec.into_iter() { data.extend(r.into_iter()); }
-        $crate::linalg::matrix::Matrix::from_vec(n, n, data)
+        $crate::linalg::matrix::Matrix::from_vec(n, n, data).expect("Incompatible data length in matrix! macro")
     }};
     ( $( [ $( $x:expr ),* $(,)? ] ),+ $(,)? ) => {{
         // Collect rows into a Vec<Vec<_>> first
@@ -34,7 +34,7 @@ macro_rules! matrix {
         assert!(rows_vec.iter().all(|r| r.len() == n), "matrix! requires a square n x n list of rows");
         let mut data = Vec::with_capacity(n*n);
         for r in rows_vec.into_iter() { data.extend(r.into_iter()); }
-        $crate::linalg::matrix::Matrix::full(n, data)
+        $crate::linalg::matrix::Matrix::from_vec(n, n, data).expect("Incompatible data length in matrix! macro")
     }};
 }
 

--- a/src/linalg/matrix/mul.rs
+++ b/src/linalg/matrix/mul.rs
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn mul_matrix_full() {
-        let a: Matrix<f64> = Matrix::from_vec(2, 2, vec![1.0, 2.0, 3.0, 4.0]);
+        let a: Matrix<f64> = Matrix::from_vec(2, 2, vec![1.0, 2.0, 3.0, 4.0]).unwrap();
         let s = 5.0;
         let out = a.component_mul(s);
         assert_eq!(out[(0, 0)], 5.0);

--- a/src/linalg/matrix/sub.rs
+++ b/src/linalg/matrix/sub.rs
@@ -265,7 +265,7 @@ mod tests {
 
     #[test]
     fn sub_scalar_full() {
-        let m: Matrix<f64> = Matrix::from_vec(2, 2, vec![1.0, 2.0, 3.0, 4.0]);
+        let m: Matrix<f64> = Matrix::from_vec(2, 2, vec![1.0, 2.0, 3.0, 4.0]).unwrap();
         let r = m.component_sub(1.0);
         assert_eq!(r[(0, 0)], 0.0);
         assert_eq!(r[(0, 1)], 1.0);
@@ -286,8 +286,8 @@ mod tests {
 
     #[test]
     fn sub_matrix_full_full() {
-        let a: Matrix<f64> = Matrix::from_vec(2, 2, vec![1.0, 2.0, 3.0, 4.0]);
-        let b: Matrix<f64> = Matrix::from_vec(2, 2, vec![4.0, 3.0, 2.0, 1.0]);
+        let a: Matrix<f64> = Matrix::from_vec(2, 2, vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+        let b: Matrix<f64> = Matrix::from_vec(2, 2, vec![4.0, 3.0, 2.0, 1.0]).unwrap();
         let r = a - b;
         assert_eq!(r[(0, 0)], -3.0);
         assert_eq!(r[(0, 1)], -1.0);

--- a/src/linalg/schur.rs
+++ b/src/linalg/schur.rs
@@ -100,10 +100,10 @@ mod tests {
     #[test]
     fn schur_mixed_blocks_small_dense() {
         // Choose small invertible A and and simple B, C
-        let a: Matrix<f64> = Matrix::from_vec(2, 2, vec![3.0, 1.0, 2.0, 4.0]);
-        let d: Matrix<f64> = Matrix::from_vec(2, 2, vec![2.0, 0.5, 1.0, 3.0]);
-        let b: Matrix<f64> = Matrix::from_vec(2, 2, vec![1.0, 0.0, 0.0, 1.0]);
-        let c: Matrix<f64> = Matrix::from_vec(2, 2, vec![0.5, 0.0, 0.0, 0.5]);
+        let a: Matrix<f64> = Matrix::from_vec(2, 2, vec![3.0, 1.0, 2.0, 4.0]).unwrap();
+        let d: Matrix<f64> = Matrix::from_vec(2, 2, vec![2.0, 0.5, 1.0, 3.0]).unwrap();
+        let b: Matrix<f64> = Matrix::from_vec(2, 2, vec![1.0, 0.0, 0.0, 1.0]).unwrap();
+        let c: Matrix<f64> = Matrix::from_vec(2, 2, vec![0.5, 0.0, 0.0, 0.5]).unwrap();
 
         let x_true = Vector2::new(1.0, -2.0);
         let y_true = Vector2::new(3.0, 4.0);


### PR DESCRIPTION
Changes Matrix::from_vec from a panicking constructor to a fallible constructor returning Result<Self, LinalgError>.\n\nThis also updates matrix! macro internals, documentation examples, and internal tests/call sites. Added coverage for incompatible input lengths.\n\nValidation:\n- cargo fmt --check\n- cargo test\n- cargo clippy --all-targets --all-features -- -D warnings