### PR TITLE
🧹 Refactor examples to prefer standard library arrays and clean up imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,6 @@ path = "examples/ode/04_sir_model/main.rs"
 [[example]]
 name = "ode_05_damped_pendulum"
 path = "examples/ode/05_damped_pendulum/main.rs"
-required-features = ["nalgebra"]
 
 [[example]]
 name = "ode_06_integration"
@@ -104,7 +103,6 @@ required-features = ["nalgebra"]
 [[example]]
 name = "ode_08_damped_oscillator"
 path = "examples/ode/08_damped_oscillator/main.rs"
-required-features = ["nalgebra"]
 
 [[example]]
 name = "ode_09_matrix_ode"
@@ -114,7 +112,6 @@ required-features = ["nalgebra"]
 [[example]]
 name = "ode_10_custom_solout"
 path = "examples/ode/10_custom_solout/main.rs"
-required-features = ["nalgebra"]
 
 [[example]]
 name = "ode_11_schrodinger"
@@ -123,12 +120,10 @@ path = "examples/ode/11_schrodinger/main.rs"
 [[example]]
 name = "ode_12_brusselator"
 path = "examples/ode/12_brusselator/main.rs"
-required-features = ["nalgebra"]
 
 [[example]]
 name = "ode_13_vanderpol"
 path = "examples/ode/13_vanderpol/main.rs"
-required-features = ["nalgebra"]
 
 [[example]]
 name = "ode_14_r2bp_stm"
@@ -148,23 +143,19 @@ required-features = ["nalgebra"]
 [[example]]
 name = "ode_17_quadrature"
 path = "examples/ode/17_quadrature/main.rs"
-required-features = ["nalgebra"]
 
 # Differential-Algebraic Equation (DAE) examples
 [[example]]
 name = "dae_01_amplifier"
 path = "examples/dae/01_amplifier/main.rs"
-required-features = ["nalgebra"]
 
 [[example]]
 name = "dae_02_robertson"
 path = "examples/dae/02_robertson/main.rs"
-required-features = ["nalgebra"]
 
 [[example]]
 name = "dae_03_pendulum"
 path = "examples/dae/03_pendulum/main.rs"
-required-features = ["nalgebra"]
 
 # Stochastic Differential Equation (SDE) examples
 [[example]]
@@ -178,7 +169,6 @@ path = "examples/sde/02_heston_model/main.rs"
 [[example]]
 name = "sde_03_ornstein_uhlenbeck"
 path = "examples/sde/03_ornstein_uhlenbeck/main.rs"
-required-features = ["nalgebra"]
 
 # Delay Differential Equation (DDE) examples
 [[example]]
@@ -188,7 +178,6 @@ path = "examples/dde/01_mackey_glass/main.rs"
 [[example]]
 name = "dde_02_breast_cancer_model"
 path = "examples/dde/02_breast_cancer_model/main.rs"
-required-features = ["nalgebra"]
 
 # Benchmarks
 [[bench]]

--- a/examples/dae/01_amplifier/main.rs
+++ b/examples/dae/01_amplifier/main.rs
@@ -24,9 +24,7 @@
 //! - Working with singular mass matrices (index-1 DAE)
 //! - Using implicit Runge-Kutta methods for stiff DAE problems
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
-use nalgebra::{SVector, vector};
 
 /// Amplifier DAE Model
 struct AmplifierModel {
@@ -82,8 +80,8 @@ impl AmplifierModel {
     }
 }
 
-impl DAE<f64, SVector<f64, 8>> for AmplifierModel {
-    fn diff(&self, t: f64, y: &SVector<f64, 8>, f: &mut SVector<f64, 8>) {
+impl DAE<f64, [f64; 8]> for AmplifierModel {
+    fn diff(&self, t: f64, y: &[f64; 8], f: &mut [f64; 8]) {
         // Sinusoidal input voltage
         let w = 2.0 * std::f64::consts::PI * 100.0;
         let uet = self.ue * (w * t).sin();
@@ -125,7 +123,7 @@ impl DAE<f64, SVector<f64, 8>> for AmplifierModel {
         m[(7, 6)] = self.c1;
     }
 
-    fn jacobian(&self, _t: f64, y: &SVector<f64, 8>, jac: &mut Matrix<f64>) {
+    fn jacobian(&self, _t: f64, y: &[f64; 8], jac: &mut Matrix<f64>) {
         // Sensitivities of exponential terms
         let g14 = self.beta * ((y[3] - y[2]) / self.uf).exp() / self.uf;
         let g27 = self.beta * ((y[6] - y[5]) / self.uf).exp() / self.uf;
@@ -169,7 +167,7 @@ fn main() {
     let model = AmplifierModel::new();
 
     // Initial conditions (computed from circuit steady-state)
-    let y0 = vector![
+    let y0 = [
         0.0,
         model.ub - 0.0 * model.r8 / model.r9,
         model.ub / (model.r6 / model.r5 + 1.0),

--- a/examples/dae/02_robertson/main.rs
+++ b/examples/dae/02_robertson/main.rs
@@ -22,9 +22,7 @@
 //! The system is highly stiff with widely separated time scales, making it
 //! an excellent test case for implicit DAE solvers.
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
-use nalgebra::{SVector, vector};
 use quill::prelude::*;
 
 /// Robertson Chemical Kinetics DAE Model
@@ -41,8 +39,8 @@ impl RobertsonModel {
 }
 
 // State vector: [y1, y2, y3] representing concentrations of species A, B, C
-impl DAE<f64, SVector<f64, 3>> for RobertsonModel {
-    fn diff(&self, _t: f64, y: &SVector<f64, 3>, f: &mut SVector<f64, 3>) {
+impl DAE<f64, [f64; 3]> for RobertsonModel {
+    fn diff(&self, _t: f64, y: &[f64; 3], f: &mut [f64; 3]) {
         let y1 = y[0]; // Concentration of A
         let y2 = y[1]; // Concentration of B
         let y3 = y[2]; // Concentration of C
@@ -60,7 +58,7 @@ impl DAE<f64, SVector<f64, 3>> for RobertsonModel {
         m[(2, 2)] = 0.0; // Conservation constraint (algebraic)
     }
 
-    fn jacobian(&self, _t: f64, y: &SVector<f64, 3>, j: &mut Matrix<f64>) {
+    fn jacobian(&self, _t: f64, y: &[f64; 3], j: &mut Matrix<f64>) {
         let y2 = y[1];
         let y3 = y[2];
 
@@ -90,7 +88,7 @@ fn main() {
     let model = RobertsonModel::new(k1, k2, k3);
 
     // Initial conditions: all A, no B or C
-    let y0 = vector![
+    let y0 = [
         1.0, // y1 = A concentration
         0.0, // y2 = B concentration
         0.0, // y3 = C concentration

--- a/examples/dae/03_pendulum/main.rs
+++ b/examples/dae/03_pendulum/main.rs
@@ -25,9 +25,7 @@
 //!       0, -lambda,0, 0, -y
 //!       2x, 2y, 0, 0, 0 ]
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
-use nalgebra::{SVector, vector};
 use quill::prelude::*;
 
 struct Pendulum {
@@ -42,8 +40,8 @@ impl Pendulum {
 }
 
 // State vector: [x, y, vx, vy, lambda]
-impl DAE<f64, SVector<f64, 5>> for Pendulum {
-    fn diff(&self, _t: f64, y: &SVector<f64, 5>, f: &mut SVector<f64, 5>) {
+impl DAE<f64, [f64; 5]> for Pendulum {
+    fn diff(&self, _t: f64, y: &[f64; 5], f: &mut [f64; 5]) {
         let x = y[0];
         let yy = y[1];
         let vx = y[2];
@@ -70,7 +68,7 @@ impl DAE<f64, SVector<f64, 5>> for Pendulum {
         m[(4, 4)] = 0.0;
     }
 
-    fn jacobian(&self, _t: f64, y: &SVector<f64, 5>, j: &mut Matrix<f64>) {
+    fn jacobian(&self, _t: f64, y: &[f64; 5], j: &mut Matrix<f64>) {
         let x = y[0];
         let yy = y[1];
         let lambda = y[4];
@@ -128,7 +126,7 @@ fn main() {
     // x*ax + y*ay + vx^2 + vy^2 = 0, with ax = -lambda*x, ay = -lambda*y - g
     // => -lambda*(x^2 + y^2) - y*g + vx^2 + vy^2 = 0  => lambda = -( - y*g + vx^2 + vy^2)/(l^2)
     let lambda0 = -(-y0 * g + vx0 * vx0 + vy0 * vy0) / (l * l);
-    let y0 = vector![x0, y0, vx0, vy0, lambda0];
+    let y0 = [x0, y0, vx0, vy0, lambda0];
     let t0 = 0.0;
     let tf = 10.0;
     match IVP::dae(&model, t0, tf, y0)

--- a/examples/dde/01_mackey_glass/main.rs
+++ b/examples/dde/01_mackey_glass/main.rs
@@ -14,7 +14,6 @@
 //!
 //! This equation was originally proposed as a model for the production of blood cells.
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
 use quill::prelude::*;
 

--- a/examples/dde/02_breast_cancer_model/main.rs
+++ b/examples/dde/02_breast_cancer_model/main.rs
@@ -16,9 +16,7 @@
 //! - u₃(t-τ) is the value of the third component at a delayed time t - τ.
 //! - p₀, q₀, v₀, d₀, p₁, q₁, v₁, d₁, d₂, β₀, β₁, τ are model parameters.
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
-use nalgebra::Vector3;
 use quill::prelude::*;
 
 struct BreastCancerModel {
@@ -36,8 +34,8 @@ struct BreastCancerModel {
     tau: f64,
 }
 
-impl DDE<1, f64, Vector3<f64>> for BreastCancerModel {
-    fn diff(&self, _t: f64, u: &Vector3<f64>, ud: &[Vector3<f64>; 1], dudt: &mut Vector3<f64>) {
+impl DDE<1, f64, [f64; 3]> for BreastCancerModel {
+    fn diff(&self, _t: f64, u: &[f64; 3], ud: &[[f64; 3]; 1], dudt: &mut [f64; 3]) {
         let hist3 = ud[0][2];
 
         let term0_common = self.v0 / (1.0 + self.beta0 * hist3.powi(2));
@@ -50,7 +48,7 @@ impl DDE<1, f64, Vector3<f64>> for BreastCancerModel {
         dudt[2] = term1_common * (1.0 - self.p1 + self.q1) * u[1] - self.d2 * u[2];
     }
 
-    fn lags(&self, _t: f64, _y: &Vector3<f64>, lags: &mut [f64; 1]) {
+    fn lags(&self, _t: f64, _y: &[f64; 3], lags: &mut [f64; 1]) {
         lags[0] = self.tau;
     }
 }
@@ -74,8 +72,8 @@ fn main() {
     };
     let t0 = 0.0;
     let tf = 10.0;
-    let y0 = Vector3::new(1.0, 1.0, 1.0);
-    let phi = |_t: f64| -> Vector3<f64> { y0 };
+    let y0 = [1.0, 1.0, 1.0];
+    let phi = |_t: f64| -> [f64; 3] { y0 };
 
     // --- Solve the Problem ---
     println!(

--- a/examples/ode/01_exponential_growth/main.rs
+++ b/examples/ode/01_exponential_growth/main.rs
@@ -17,7 +17,6 @@
 //! - Setting custom tolerances for high accuracy
 //! - Accessing solution statistics like step counts and evaluations
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
 use quill::prelude::*;
 

--- a/examples/ode/02_harmonic_oscillator/main.rs
+++ b/examples/ode/02_harmonic_oscillator/main.rs
@@ -19,7 +19,6 @@
 //! - Using `Vec<f64>` for dynamically sized state representation
 //! - Compact solution approach with minimal code
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
 use quill::prelude::*;
 

--- a/examples/ode/03_logistic_growth/main.rs
+++ b/examples/ode/03_logistic_growth/main.rs
@@ -17,7 +17,6 @@
 //! - Handling events during the solution process
 //! - Accessing solution statistics like step counts and evaluations
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
 use ndarray::{Array1, array};
 use quill::prelude::*;

--- a/examples/ode/04_sir_model/main.rs
+++ b/examples/ode/04_sir_model/main.rs
@@ -22,7 +22,6 @@
 //! - Setting up even-interval output points
 //! - Working with solution status information
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
 use quill::prelude::*;
 

--- a/examples/ode/05_damped_pendulum/main.rs
+++ b/examples/ode/05_damped_pendulum/main.rs
@@ -21,9 +21,7 @@
 //! - Evaluation at specific time points (t_eval)
 //! - Status checking with simulation results
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
-use nalgebra::{SVector, vector};
 
 struct DampedPendulumModel {
     g: f64,
@@ -32,8 +30,8 @@ struct DampedPendulumModel {
     m: f64,
 }
 
-impl ODE<f64, SVector<f64, 2>> for DampedPendulumModel {
-    fn diff(&self, _t: f64, y: &SVector<f64, 2>, dydt: &mut SVector<f64, 2>) {
+impl ODE<f64, [f64; 2]> for DampedPendulumModel {
+    fn diff(&self, _t: f64, y: &[f64; 2], dydt: &mut [f64; 2]) {
         let theta = y[0];
         let omega = y[1];
 
@@ -42,13 +40,13 @@ impl ODE<f64, SVector<f64, 2>> for DampedPendulumModel {
     }
 }
 
-impl Event<f64, SVector<f64, 2>> for DampedPendulumModel {
+impl Event<f64, [f64; 2]> for DampedPendulumModel {
     fn config(&self) -> EventConfig {
         EventConfig::default().terminal() // Will terminate after the first event
     }
 
     /// Event function to detect when the pendulum is near equilibrium
-    fn event(&self, _t: f64, y: &SVector<f64, 2>) -> f64 {
+    fn event(&self, _t: f64, y: &[f64; 2]) -> f64 {
         let theta = y[0];
         let omega = y[1];
         // Event function g(t,y) = max(|theta|, |omega|) - 0.01
@@ -60,7 +58,7 @@ fn main() {
     // --- Problem Configuration ---
     let initial_angle = 1.0; // Initial angle (radians)
     let initial_velocity = 0.0; // Initial angular velocity (radians/s)
-    let y0 = vector![initial_angle, initial_velocity];
+    let y0 = [initial_angle, initial_velocity];
     let t0 = 0.0;
     let tf = 100.0;
 

--- a/examples/ode/06_integration/main.rs
+++ b/examples/ode/06_integration/main.rs
@@ -16,7 +16,6 @@
 //! - Different output options: dense, even, and t-eval
 //! - Error assessment in numerical integration
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
 use faer::Mat;
 

--- a/examples/ode/07_cr3bp/main.rs
+++ b/examples/ode/07_cr3bp/main.rs
@@ -22,7 +22,6 @@
 //! - State extraction for specialized calculations
 
 use differential_equations::derive::State;
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
 use nalgebra::{Vector3, vector};
 

--- a/examples/ode/08_damped_oscillator/main.rs
+++ b/examples/ode/08_damped_oscillator/main.rs
@@ -17,17 +17,15 @@
 //! This example showcases:
 //! - Zero-crossing detection with the crossing() method
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
-use nalgebra::{SVector, vector};
 
 struct DampedOscillator {
     damping: f64,
     spring_constant: f64,
 }
 
-impl ODE<f64, SVector<f64, 2>> for DampedOscillator {
-    fn diff(&self, _t: f64, y: &SVector<f64, 2>, dydt: &mut SVector<f64, 2>) {
+impl ODE<f64, [f64; 2]> for DampedOscillator {
+    fn diff(&self, _t: f64, y: &[f64; 2], dydt: &mut [f64; 2]) {
         dydt[0] = y[1];
         dydt[1] = -self.damping * y[1] - self.spring_constant * y[0];
     }
@@ -41,7 +39,7 @@ fn main() {
         damping,
         spring_constant,
     };
-    let y0 = vector![1.0, 0.0];
+    let y0 = [1.0, 0.0];
     let t0 = 0.0;
     let tf = 20.0;
 

--- a/examples/ode/09_matrix_ode/main.rs
+++ b/examples/ode/09_matrix_ode/main.rs
@@ -21,7 +21,6 @@
 //! - Comparing numerical solution with analytical matrix exponential
 //! - Understanding matrix evolution in continuous time
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
 use nalgebra::SMatrix;
 

--- a/examples/ode/10_custom_solout/main.rs
+++ b/examples/ode/10_custom_solout/main.rs
@@ -21,9 +21,7 @@
 //! - Event detection during solution output
 //! - Energy conservation monitoring with high-accuracy solvers
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
-use nalgebra::{SVector, vector};
 use std::f64::consts::PI;
 
 struct Pendulum {
@@ -31,8 +29,8 @@ struct Pendulum {
     l: f64,
 }
 
-impl ODE<f64, SVector<f64, 2>> for Pendulum {
-    fn diff(&self, _t: f64, y: &SVector<f64, 2>, dydt: &mut SVector<f64, 2>) {
+impl ODE<f64, [f64; 2]> for Pendulum {
+    fn diff(&self, _t: f64, y: &[f64; 2], dydt: &mut [f64; 2]) {
         dydt[0] = y[1];
         dydt[1] = -self.g / self.l * y[0].sin();
     }
@@ -76,7 +74,7 @@ impl PendulumSolout {
     }
 
     // Calculate the total energy of the pendulum
-    fn calculate_energy(&self, y: &SVector<f64, 2>) -> f64 {
+    fn calculate_energy(&self, y: &[f64; 2]) -> f64 {
         let theta = y[0];
         let omega = y[1];
 
@@ -90,18 +88,18 @@ impl PendulumSolout {
     }
 }
 
-impl Solout<f64, SVector<f64, 2>> for PendulumSolout {
+impl Solout<f64, [f64; 2]> for PendulumSolout {
     fn solout<I>(
         &mut self,
         t_curr: f64,
         _t_prev: f64,
-        y_curr: &SVector<f64, 2>,
-        _y_prev: &SVector<f64, 2>,
+        y_curr: &[f64; 2],
+        _y_prev: &[f64; 2],
         _interpolator: &mut I,
-        solution: &mut Solution<f64, SVector<f64, 2>>,
-    ) -> ControlFlag<f64, SVector<f64, 2>>
+        solution: &mut Solution<f64, [f64; 2]>,
+    ) -> ControlFlag<f64, [f64; 2]>
     where
-        I: Interpolation<f64, SVector<f64, 2>>,
+        I: Interpolation<f64, [f64; 2]>,
     {
         let current_angle = y_curr[0];
         let dt = t_curr - self.last_output_time;
@@ -156,7 +154,7 @@ fn main() {
     let l = 1.0;
     let pendulum = Pendulum { g, l };
     let theta0 = 30.0 * PI / 180.0; // convert to radians
-    let y0 = vector![theta0, 0.0];
+    let y0 = [theta0, 0.0];
     let t0 = 0.0;
     let tf = 10.0;
     let energy = PendulumSolout::new(g, l, 0.1);

--- a/examples/ode/11_schrodinger/main.rs
+++ b/examples/ode/11_schrodinger/main.rs
@@ -23,7 +23,6 @@
 //! - Phase evolution in quantum systems
 //! - Verifying numerical accuracy against analytical predictions
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
 use num_complex::Complex;
 

--- a/examples/ode/12_brusselator/main.rs
+++ b/examples/ode/12_brusselator/main.rs
@@ -14,14 +14,12 @@
 //! J = [[-4 + 2*y0*y1,     y0^2],
 //!      [ 3 - 2*y0*y1,    -y0^2]]
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
-use nalgebra::Vector2;
 
 struct BrusselatorSystem;
 
-impl ODE<f64, Vector2<f64>> for BrusselatorSystem {
-    fn diff(&self, _t: f64, y: &Vector2<f64>, dydt: &mut Vector2<f64>) {
+impl ODE<f64, [f64; 2]> for BrusselatorSystem {
+    fn diff(&self, _t: f64, y: &[f64; 2], dydt: &mut [f64; 2]) {
         let y0 = y[0];
         let y1 = y[1];
 
@@ -29,7 +27,7 @@ impl ODE<f64, Vector2<f64>> for BrusselatorSystem {
         dydt[1] = 3.0 * y0 - y0 * y0 * y1;
     }
 
-    fn jacobian(&self, _t: f64, y: &Vector2<f64>, j: &mut Matrix<f64>) {
+    fn jacobian(&self, _t: f64, y: &[f64; 2], j: &mut Matrix<f64>) {
         let y0 = y[0];
         let y1 = y[1];
 
@@ -42,7 +40,7 @@ impl ODE<f64, Vector2<f64>> for BrusselatorSystem {
 
 fn main() {
     // --- Problem Configuration ---
-    let y0 = Vector2::new(1.5, 3.0);
+    let y0 = [1.5, 3.0];
     let t0 = 0.0;
     let tf = 20.0;
     let ode = BrusselatorSystem;

--- a/examples/ode/13_vanderpol/main.rs
+++ b/examples/ode/13_vanderpol/main.rs
@@ -14,9 +14,7 @@
 //! J = [[0, 1],
 //!      [(-2*y0*y1 - 1)/mu,  (1 - y0^2)/mu]]
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
-use nalgebra::Vector2;
 
 struct VanderPol {
     mu: f64,
@@ -28,13 +26,13 @@ impl VanderPol {
     }
 }
 
-impl ODE<f64, Vector2<f64>> for VanderPol {
-    fn diff(&self, _t: f64, y: &Vector2<f64>, dydt: &mut Vector2<f64>) {
+impl ODE<f64, [f64; 2]> for VanderPol {
+    fn diff(&self, _t: f64, y: &[f64; 2], dydt: &mut [f64; 2]) {
         dydt[0] = y[1];
         dydt[1] = ((1.0 - y[0] * y[0]) * y[1] - y[0]) / self.mu;
     }
 
-    fn jacobian(&self, _t: f64, y: &Vector2<f64>, j: &mut Matrix<f64>) {
+    fn jacobian(&self, _t: f64, y: &[f64; 2], j: &mut Matrix<f64>) {
         j[(0, 0)] = 0.0;
         j[(0, 1)] = 1.0;
         j[(1, 0)] = (-2.0 * y[0] * y[1] - 1.0) / self.mu;
@@ -44,7 +42,7 @@ impl ODE<f64, Vector2<f64>> for VanderPol {
 
 fn main() {
     // --- Problem Configuration ---
-    let y0 = Vector2::new(2.0, -0.66);
+    let y0 = [2.0, -0.66];
     let t0 = 0.0;
     let tf = 2.0;
     let mu = 1.0e-6; // small parameter -> stiff

--- a/examples/ode/14_r2bp_stm/main.rs
+++ b/examples/ode/14_r2bp_stm/main.rs
@@ -14,7 +14,6 @@
 //! - clamp, quantize, or otherwise normalize step sizes for reproducibility
 //!   or custom time-stepping rules
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
 use differential_equations::{ode::ODE, traits::Real};
 use nalgebra::{Dim, Matrix3, Matrix6, SVector, Vector6, stack};

--- a/examples/ode/15_forward_sensitivity_analysis/main.rs
+++ b/examples/ode/15_forward_sensitivity_analysis/main.rs
@@ -13,7 +13,6 @@
 //! The parameter is `k`. We want to know how the final state `y(t_f)` changes
 //! with respect to `k` (i.e., dy/dk).
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
 use differential_equations::traits::Real;
 use nalgebra::SVector;

--- a/examples/ode/16_adjoint_sensitivities/main.rs
+++ b/examples/ode/16_adjoint_sensitivities/main.rs
@@ -6,7 +6,6 @@
 //! ASA calculates the gradient of a cost function with respect to parameters
 //! by solving an adjoint ODE backward in time.
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
 use nalgebra::{Matrix2, SVector, vector};
 

--- a/examples/ode/17_quadrature/main.rs
+++ b/examples/ode/17_quadrature/main.rs
@@ -35,9 +35,7 @@
 //!   not force additional step rejections while still riding along at full accuracy
 //! - Verifying quadrature accuracy against a conservation-of-energy check
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
-use nalgebra::{SVector, vector};
 use quill::prelude::*;
 
 struct DampedOscillator {
@@ -46,8 +44,8 @@ struct DampedOscillator {
     c: f64,
 }
 
-impl ODE<f64, SVector<f64, 3>> for DampedOscillator {
-    fn diff(&self, _t: f64, y: &SVector<f64, 3>, dydt: &mut SVector<f64, 3>) {
+impl ODE<f64, [f64; 3]> for DampedOscillator {
+    fn diff(&self, _t: f64, y: &[f64; 3], dydt: &mut [f64; 3]) {
         let x = y[0];
         let v = y[1];
         dydt[0] = v;
@@ -64,7 +62,7 @@ fn main() {
 
     let t0 = 0.0;
     let tf = 20.0;
-    let y0: SVector<f64, 3> = vector![1.0, 0.0, 0.0];
+    let y0: [f64; 3] = [1.0, 0.0, 0.0];
 
     let e0 = 0.5 * k * y0[0] * y0[0] + 0.5 * m * y0[1] * y0[1];
 

--- a/examples/sde/01_brownian_motion/main.rs
+++ b/examples/sde/01_brownian_motion/main.rs
@@ -11,7 +11,6 @@
 //! moves randomly due to collisions with molecules. It has many applications
 //! in science, finance, and mathematics.
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
 use quill::prelude::*;
 use rand::SeedableRng;

--- a/examples/sde/03_ornstein_uhlenbeck/main.rs
+++ b/examples/sde/03_ornstein_uhlenbeck/main.rs
@@ -14,9 +14,7 @@
 //! It has applications in physics, finance (for modeling interest rates), and
 //! various other fields.
 
-use differential_equations::ivp::IVP;
 use differential_equations::prelude::*;
-use nalgebra::Vector1;
 use rand::SeedableRng;
 use rand_distr::{Distribution, Normal};
 
@@ -38,16 +36,16 @@ impl OrnsteinUhlenbeck {
     }
 }
 
-impl SDE<f64, Vector1<f64>> for OrnsteinUhlenbeck {
-    fn drift(&self, _t: f64, y: &Vector1<f64>, dydt: &mut Vector1<f64>) {
+impl SDE<f64, [f64; 1]> for OrnsteinUhlenbeck {
+    fn drift(&self, _t: f64, y: &[f64; 1], dydt: &mut [f64; 1]) {
         dydt[0] = self.theta * (self.mu - y[0]);
     }
 
-    fn diffusion(&self, _t: f64, _y: &Vector1<f64>, dydw: &mut Vector1<f64>) {
+    fn diffusion(&self, _t: f64, _y: &[f64; 1], dydw: &mut [f64; 1]) {
         dydw[0] = self.sigma;
     }
 
-    fn noise(&mut self, dt: f64, dw: &mut Vector1<f64>) {
+    fn noise(&mut self, dt: f64, dw: &mut [f64; 1]) {
         let normal = Normal::new(0.0, dt.sqrt()).unwrap();
         dw[0] = normal.sample(&mut self.rng);
     }
@@ -65,7 +63,7 @@ fn main() {
     // Time settings
     let t0 = 0.0;
     let tf = 10.0;
-    let y0 = Vector1::new(5.0); // Initial value, far from mean
+    let y0 = [5.0]; // Initial value, far from mean
 
     // Create the Ornstein-Uhlenbeck SDE problem
     let mut sde = OrnsteinUhlenbeck::new(theta, mu, sigma, seed);
@@ -85,7 +83,7 @@ fn main() {
     println!("Simulating Ornstein-Uhlenbeck process with parameters:");
     println!("θ = {}, μ = {}, σ = {}", theta, mu, sigma);
     println!("Time interval: [{}, {}], Step size: {}", t0, tf, dt);
-    println!("Initial value: {}", y0);
+    println!("Initial value: {}", y0[0]);
     println!("Random seed: {}", seed);
     println!("Simulation completed:");
     println!("  Number of time steps: {}", solution.t.len());
@@ -107,6 +105,6 @@ fn main() {
 
     println!("\nIntermediate values:");
     for (t, y) in solution.iter() {
-        println!("  t = {:.2}: y = {:.6}", t, y);
+        println!("  t = {:.2}: y = {:.6}", t, y[0]);
     }
 }


### PR DESCRIPTION
What:
- Converted 11 examples (across ODE, DAE, SDE, DDE) to use standard Rust arrays (`[f64; N]`) instead of `nalgebra` vectors.
- Kept `nalgebra` usage limited to a few specific examples (e.g., matrix math or dual numbers) to prevent bias towards a single external crate.
- Removed the redundant `use differential_equations::ivp::IVP;` import from all examples, as it is already available via the prelude.
- Updated `Cargo.toml` to remove `required-features = ["nalgebra"]` from the converted examples.

Why:
- To make the library examples more accessible to users who do not wish to use `nalgebra`.
- To reduce visual clutter and reliance on redundant imports.

Verification:
- Checked compilation of all examples via `cargo check --examples --all-features`.
- Verified logic via `cargo test --examples --all-features`.

Result:
- Cleaned up example codebase, demonstrating the library's native compatibility with standard Rust types.

---
*PR created automatically by Jules for task [15428165923787761379](https://jules.google.com/task/15428165923787761379) started by @Ryan-D-Gast*