### PR TITLE
refactor(error): actionable error types for solver failures

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -37,7 +37,7 @@ where
     InsufficientHistory { t_delayed: T, t_prev: T, t_curr: T },
 
     /// General linear algebra error
-    LinearAlgebra { msg: String },
+    LinearAlgebra { t: T, y: Y, msg: String },
 }
 
 impl<T, Y> Display for Error<T, Y>
@@ -95,7 +95,11 @@ where
                     t_delayed, t_prev, t_curr
                 )
             }
-            Self::LinearAlgebra { msg } => write!(f, "Linear algebra error: {}", msg),
+            Self::LinearAlgebra { t, y, msg } => write!(
+                f,
+                "Linear algebra error at (t, y) = ({}, {}): {}",
+                t, y, msg
+            ),
         }
     }
 }
@@ -159,7 +163,11 @@ where
                     t_delayed, t_prev, t_curr
                 )
             }
-            Self::LinearAlgebra { msg } => write!(f, "Linear algebra error: {}", msg),
+            Self::LinearAlgebra { t, y, msg } => write!(
+                f,
+                "Linear algebra error at (t, y) = ({:?}, {:?}): {}",
+                t, y, msg
+            ),
         }
     }
 }

--- a/src/linalg/error.rs
+++ b/src/linalg/error.rs
@@ -1,10 +1,5 @@
 //! Linear algebra error types.
 
-use crate::{
-    error,
-    traits::{Real, State},
-};
-
 /// Errors that can occur during linear algebra operations.
 #[derive(Debug, Clone, PartialEq)]
 pub enum LinalgError {
@@ -35,17 +30,3 @@ impl std::fmt::Display for LinalgError {
 }
 
 impl std::error::Error for LinalgError {}
-
-// Allow using `?` to bubble LinalgError into the crate's generic Error<T, Y>.
-impl<T, Y> From<LinalgError> for error::Error<T, Y>
-where
-    T: Real,
-    Y: State<T>,
-{
-    fn from(err: LinalgError) -> Self {
-        // Map linear algebra errors into a user-facing message.
-        error::Error::LinearAlgebra {
-            msg: err.to_string(),
-        }
-    }
-}

--- a/src/linalg/matrix/linear.rs
+++ b/src/linalg/matrix/linear.rs
@@ -1,7 +1,6 @@
 //! Linear solves: A x = b via LU with partial pivoting on a dense copy.
 
 use crate::{
-    error::Error,
     linalg::LinalgError,
     traits::{Real, State},
 };
@@ -10,19 +9,19 @@ use super::base::Matrix;
 
 impl<T: Real> Matrix<T> {
     /// Solve A x = b, Returns Err if the matrix is singular or dimensions are incompatible
-    pub fn lin_solve<Y>(&self, b: Y) -> Result<Y, Error<T, Y>>
+    pub fn lin_solve<Y>(&self, b: Y) -> Result<Y, LinalgError>
     where
         Y: State<T>,
     {
         let n = self.n;
         if self.m != n {
-            return Err(Error::BadInput {
-                msg: "Matrix solve requires a square matrix".into(),
+            return Err(LinalgError::BadInput {
+                message: "Matrix solve requires a square matrix".into(),
             });
         }
         if b.len() != n {
-            return Err(Error::BadInput {
-                msg: "Incompatible vector length".into(),
+            return Err(LinalgError::BadInput {
+                message: "Incompatible vector length".into(),
             });
         }
 
@@ -51,7 +50,7 @@ impl<T: Real> Matrix<T> {
             // Check for singularity
             if pivot_val <= eps {
                 // Note the t, y are not known here and should be updated by caller before returning to user
-                return Err(LinalgError::Singular { step: k + 1 }.into());
+                return Err(LinalgError::Singular { step: k + 1 });
             }
 
             if pivot_row != k {

--- a/src/linalg/schur.rs
+++ b/src/linalg/schur.rs
@@ -19,7 +19,7 @@ pub fn schur_complement<T: Real, V: State<T>>(
     d: &Matrix<T>,
     r: V,
     s: V,
-) -> (V, V) {
+) -> Result<(V, V), crate::linalg::LinalgError> {
     let n = a.n;
     assert_eq!(b.n, n, "block size mismatch: B");
     assert_eq!(c.n, n, "block size mismatch: C");
@@ -28,7 +28,7 @@ pub fn schur_complement<T: Real, V: State<T>>(
     assert_eq!(s.len(), n, "rhs s size mismatch");
 
     // Helper: solve with A and D using existing dense LU path
-    let solve_a = |rhs: V| a.lin_solve(rhs).unwrap();
+    let solve_a = |rhs: V| a.lin_solve(rhs);
 
     // Build dense Schur complement S = D - C A^{-1} B, as a dense Full matrix
     // We'll fill column-by-column using basis vectors e_j.
@@ -40,7 +40,7 @@ pub fn schur_complement<T: Real, V: State<T>>(
         // u = B e_j
         let u = b.mul_state::<V>(&e);
         // v = A^{-1} u
-        let v = solve_a(u);
+        let v = solve_a(u)?;
         // z = C v
         let z = c.mul_state::<V>(&v);
         // column j of S is (D e_j - z)
@@ -52,19 +52,19 @@ pub fn schur_complement<T: Real, V: State<T>>(
     }
 
     // Compute w = s - C A^{-1} r
-    let ar = solve_a(r.clone());
+    let ar = solve_a(r.clone())?;
     let car = c.mul_state::<V>(&ar);
     let w = s.minus(&car);
 
     // Solve S y = w
-    let y = s_dense.lin_solve(w).unwrap();
+    let y = s_dense.lin_solve(w)?;
 
     // Back-substitute for x: A x = r - B y
     let by = b.mul_state::<V>(&y);
     let rhs_x = r.minus(&by);
-    let x = solve_a(rhs_x);
+    let x = solve_a(rhs_x)?;
 
-    (x, y)
+    Ok((x, y))
 }
 
 #[cfg(all(test, feature = "nalgebra"))]
@@ -90,7 +90,7 @@ mod tests {
         let r = a.mul_state(&x_true);
         let s = d.mul_state(&y_true);
 
-        let (x, y) = schur_complement(&a, &b, &c, &d, r, s);
+        let (x, y) = schur_complement(&a, &b, &c, &d, r, s).unwrap();
         approx_eq(x.x, x_true.x);
         approx_eq(x.y, x_true.y);
         approx_eq(y.x, y_true.x);
@@ -120,7 +120,7 @@ mod tests {
             Vector2::new(cx.x + dy.x, cx.y + dy.y)
         };
 
-        let (x, y) = schur_complement(&a, &b, &c, &d, r, s);
+        let (x, y) = schur_complement(&a, &b, &c, &d, r, s).unwrap();
         approx_eq(x.x, x_true.x);
         approx_eq(x.y, x_true.y);
         approx_eq(y.x, y_true.x);

--- a/src/methods/dirk/adaptive/ordinary.rs
+++ b/src/methods/dirk/adaptive/ordinary.rs
@@ -169,7 +169,18 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
                 self.jacobian_age += 1;
 
                 // Solve (I - h*a_ii J) Δz = -F(z) using in-place LU
-                self.delta_z = self.jacobian.lin_solve(self.rhs_newton.clone()).unwrap();
+                match self.jacobian.lin_solve(self.rhs_newton.clone()) {
+                    Ok(dz) => self.delta_z = dz,
+                    Err(e) => {
+                        let mapped_err = Error::LinearAlgebra {
+                            t: self.t,
+                            y: self.y.clone(),
+                            msg: e.to_string(),
+                        };
+                        self.status = Status::Error(mapped_err.clone());
+                        return Err(mapped_err);
+                    }
+                }
                 evals.solves += 1;
 
                 // Update z and increment norm

--- a/src/methods/dirk/fixed/ordinary.rs
+++ b/src/methods/dirk/fixed/ordinary.rs
@@ -147,7 +147,18 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
                 self.jacobian_age += 1;
 
                 // Solve (I - h*a_ii J) Δz = -F(z) using in-place LU
-                self.delta_z = self.jacobian.lin_solve(self.rhs_newton.clone()).unwrap();
+                match self.jacobian.lin_solve(self.rhs_newton.clone()) {
+                    Ok(dz) => self.delta_z = dz,
+                    Err(e) => {
+                        let mapped_err = Error::LinearAlgebra {
+                            t: self.t,
+                            y: self.y.clone(),
+                            msg: e.to_string(),
+                        };
+                        self.status = Status::Error(mapped_err.clone());
+                        return Err(mapped_err);
+                    }
+                }
                 evals.solves += 1;
 
                 // Update z and increment norm

--- a/src/methods/irk/adaptive/ordinary.rs
+++ b/src/methods/irk/adaptive/ordinary.rs
@@ -205,7 +205,12 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
                 self.delta_k_vec[i] = self.rhs_newton[i];
             }
             self.newton_matrix
-                .lin_solve_mut(&mut self.delta_k_vec[..])?;
+                .lin_solve_mut(&mut self.delta_k_vec[..])
+                .map_err(|e| crate::error::Error::LinearAlgebra {
+                    t: self.t,
+                    y: self.y.clone(),
+                    msg: e.to_string(),
+                })?;
             self.lu_decompositions += 1;
 
             // Update z_i and increment norm

--- a/src/methods/irk/fixed/ordinary.rs
+++ b/src/methods/irk/fixed/ordinary.rs
@@ -181,7 +181,13 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
 
             // Solve (I - h*A⊗J) Δz = -F(z) using in-place LU on our matrix
             let mut rhs = self.rhs_newton.clone();
-            self.newton_matrix.lin_solve_mut(&mut rhs[..])?;
+            self.newton_matrix
+                .lin_solve_mut(&mut rhs[..])
+                .map_err(|e| crate::error::Error::LinearAlgebra {
+                    t: self.t,
+                    y: self.y.clone(),
+                    msg: e.to_string(),
+                })?;
             evals.solves += 1;
 
             // Update z_i and increment norm

--- a/src/methods/irk/radau/algebraic.rs
+++ b/src/methods/irk/radau/algebraic.rs
@@ -83,9 +83,13 @@ impl<T: Real, Y: State<T>> AlgebraicNumericalMethod<T, Y> for Radau5<Algebraic, 
                 self.singular_count += 1;
                 if self.singular_count > 5 {
                     self.status = Status::Error(Error::LinearAlgebra {
+                        t: self.t,
+                        y: self.y.clone(),
                         msg: "Repeated singular matrix in step rejection; aborting.".to_string(),
                     });
                     return Err(Error::LinearAlgebra {
+                        t: self.t,
+                        y: self.y.clone(),
                         msg: "Repeated singular matrix in step rejection; aborting.".to_string(),
                     });
                 }
@@ -105,9 +109,13 @@ impl<T: Real, Y: State<T>> AlgebraicNumericalMethod<T, Y> for Radau5<Algebraic, 
                 self.singular_count += 1;
                 if self.singular_count > 5 {
                     self.status = Status::Error(Error::LinearAlgebra {
+                        t: self.t,
+                        y: self.y.clone(),
                         msg: "Repeated singular matrix in step rejection; aborting.".to_string(),
                     });
                     return Err(Error::LinearAlgebra {
+                        t: self.t,
+                        y: self.y.clone(),
                         msg: "Repeated singular matrix in step rejection; aborting.".to_string(),
                     });
                 }

--- a/src/methods/irk/radau/ordinary.rs
+++ b/src/methods/irk/radau/ordinary.rs
@@ -82,9 +82,13 @@ impl<T: Real, Y: State<T>> OrdinaryNumericalMethod<T, Y> for Radau5<Ordinary, T,
                 self.singular_count += 1;
                 if self.singular_count > 5 {
                     self.status = Status::Error(Error::LinearAlgebra {
+                        t: self.t,
+                        y: self.y.clone(),
                         msg: "Repeated singular matrix in step rejection; aborting.".to_string(),
                     });
                     return Err(Error::LinearAlgebra {
+                        t: self.t,
+                        y: self.y.clone(),
                         msg: "Repeated singular matrix in step rejection; aborting.".to_string(),
                     });
                 }
@@ -104,9 +108,13 @@ impl<T: Real, Y: State<T>> OrdinaryNumericalMethod<T, Y> for Radau5<Ordinary, T,
                 self.singular_count += 1;
                 if self.singular_count > 5 {
                     self.status = Status::Error(Error::LinearAlgebra {
+                        t: self.t,
+                        y: self.y.clone(),
                         msg: "Repeated singular matrix in step rejection; aborting.".to_string(),
                     });
                     return Err(Error::LinearAlgebra {
+                        t: self.t,
+                        y: self.y.clone(),
                         msg: "Repeated singular matrix in step rejection; aborting.".to_string(),
                     });
                 }

--- a/tests/dde/accuracy.rs
+++ b/tests/dde/accuracy.rs
@@ -3,8 +3,8 @@
 
 use super::systems::MackeyGlass;
 use differential_equations::ivp::IVP;
-use differential_equations::methods::ExplicitRungeKutta;
 use differential_equations::traits::State;
+use differential_equations::methods::ExplicitRungeKutta;
 use std::fs;
 
 macro_rules! test_dde {

--- a/tests/dde/accuracy.rs
+++ b/tests/dde/accuracy.rs
@@ -3,8 +3,8 @@
 
 use super::systems::MackeyGlass;
 use differential_equations::ivp::IVP;
-use differential_equations::traits::State;
 use differential_equations::methods::ExplicitRungeKutta;
+use differential_equations::traits::State;
 use std::fs;
 
 macro_rules! test_dde {


### PR DESCRIPTION
Improve `Error` variants to provide specific diagnostic info, specifically enriching `Error::LinearAlgebra` with temporal and spatial solver state (e.g. `t` and `y`). This provides actionable error messages for user-level APIs when encountering singularities or divergent Newton iterations due to stiffness, addressing Issue #82.

---
*PR created automatically by Jules for task [11706804888515864421](https://jules.google.com/task/11706804888515864421) started by @Ryan-D-Gast*