### PR TITLE
feat(parallel): ensemble simulation support with Rayon

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ polars = ["dep:polars"]
 serde = ["dep:serde"]
 ndarray = ["dep:ndarray"]
 faer = ["dep:faer"]
+rayon = ["dep:rayon"]
 
 [lints.clippy]
 module_inception = "allow"
@@ -51,6 +52,7 @@ polars = { version = "^0.53.0", optional = true } # DataFrame integration for th
 serde = { version = "1.0.228", features = ["derive"], optional = true } # solution serialization/deserialization
 ndarray = { version = "0.17.2", optional = true }
 faer = { version = "0.24.0", optional = true }
+rayon = { version = "1.12.0", optional = true }
 
 [dev-dependencies]
 quill = "0.2.0" # Plotting for examples
@@ -187,3 +189,13 @@ name = "ode_solver_benchmarks"
 harness = false
 path = "benches/main.rs"
 required-features = ["nalgebra"]
+
+[[example]]
+name = "sde_04_monte_carlo"
+path = "examples/sde/04_monte_carlo/main.rs"
+required-features = ["rayon"]
+
+[[test]]
+name = "parallel"
+path = "tests/parallel.rs"
+required-features = ["rayon"]

--- a/examples/sde/04_monte_carlo/main.rs
+++ b/examples/sde/04_monte_carlo/main.rs
@@ -1,0 +1,97 @@
+//! Example 04: SDE Monte Carlo Simulation
+//!
+//! This example demonstrates running many stochastic differential equation simulations
+//! in parallel using the `rayon` parallel solver integration.
+//!
+//! We simulate geometric Brownian motion (GBM), which is commonly used to model
+//! stock prices in finance. The SDE is:
+//! dS = μ·S·dt + σ·S·dW
+
+#[cfg(feature = "rayon")]
+use differential_equations::parallel::ParallelSolve;
+use differential_equations::prelude::*;
+use rand::SeedableRng;
+use rand_distr::{Distribution, Normal};
+
+struct GeometricBrownianMotion {
+    mu: f64,
+    sigma: f64,
+    rng: rand::rngs::StdRng,
+}
+
+impl GeometricBrownianMotion {
+    fn new(mu: f64, sigma: f64, seed: u64) -> Self {
+        Self {
+            mu,
+            sigma,
+            rng: rand::rngs::StdRng::seed_from_u64(seed),
+        }
+    }
+}
+
+impl SDE for GeometricBrownianMotion {
+    fn drift(&self, _t: f64, y: &f64, dydt: &mut f64) {
+        *dydt = self.mu * y;
+    }
+
+    fn diffusion(&self, _t: f64, y: &f64, dydw: &mut f64) {
+        *dydw = self.sigma * y;
+    }
+
+    fn noise(&mut self, dt: f64, dw: &mut f64) {
+        let normal = Normal::new(0.0, dt.sqrt()).unwrap();
+        *dw = normal.sample(&mut self.rng);
+    }
+}
+
+fn main() {
+    // --- Problem Configuration ---
+    let t0 = 0.0;
+    let tf = 1.0;
+    let y0 = 100.0;
+    let mu = 0.05;
+    let sigma = 0.2;
+    let dt = 0.01;
+    let num_simulations = 1000;
+
+    println!("Running {} SDE simulations...", num_simulations);
+
+    let start = std::time::Instant::now();
+
+    // Create a vector of systems (one per simulation, each with a different seed)
+    // We cannot share a single SDE system because `IVP::sde` takes `&mut system`, and mutating
+    // the system state (the RNG) concurrently is not thread-safe. So we create multiple.
+    let mut systems = Vec::new();
+    for i in 0..num_simulations {
+        systems.push(GeometricBrownianMotion::new(mu, sigma, i as u64));
+    }
+
+    // Solve in parallel
+    #[cfg(feature = "rayon")]
+    {
+        let ivps: Vec<_> = systems
+            .iter_mut()
+            .map(|sde| IVP::sde(sde, t0, tf, y0).method(ExplicitRungeKutta::euler(dt)))
+            .collect();
+
+        let results = ivps.par_solve();
+        let mut final_prices = Vec::new();
+
+        for res in results {
+            let solution = res.unwrap();
+            final_prices.push(*solution.y.last().unwrap());
+        }
+
+        let mean_price: f64 = final_prices.iter().sum::<f64>() / num_simulations as f64;
+        let expected_price = y0 * (mu * tf).exp();
+
+        println!("Completed in {:?}", start.elapsed());
+        println!("Monte Carlo Mean Final Price: {:.2}", mean_price);
+        println!("Theoretical Expected Price:   {:.2}", expected_price);
+    }
+
+    #[cfg(not(feature = "rayon"))]
+    {
+        println!("Please enable the 'rayon' feature to run the Monte Carlo simulation.");
+    }
+}

--- a/src/ivp.rs
+++ b/src/ivp.rs
@@ -361,3 +361,59 @@ where
         )
     }
 }
+
+#[cfg(feature = "rayon")]
+use crate::parallel::Solver;
+
+#[cfg(feature = "rayon")]
+impl<'a, F, T: Real, Y: State<T>, Method, SoloutType> Solver<T, Y>
+    for IVP<OdeEq<'a, F>, T, Y, Method, SoloutType>
+where
+    F: ODE<T, Y>,
+    Method: OrdinaryNumericalMethod<T, Y> + Interpolation<T, Y>,
+    SoloutType: Solout<T, Y>,
+{
+    fn solve_ivp(self) -> Result<Solution<T, Y>, Error<T, Y>> {
+        self.solve()
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, F, T: Real, Y: State<T>, Method, SoloutType> Solver<T, Y>
+    for IVP<DaeEq<'a, F>, T, Y, Method, SoloutType>
+where
+    F: DAE<T, Y>,
+    Method: AlgebraicNumericalMethod<T, Y> + Interpolation<T, Y>,
+    SoloutType: Solout<T, Y>,
+{
+    fn solve_ivp(self) -> Result<Solution<T, Y>, Error<T, Y>> {
+        self.solve()
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, F, T: Real, Y: State<T>, Method, SoloutType> Solver<T, Y>
+    for IVP<SdeEq<'a, F>, T, Y, Method, SoloutType>
+where
+    F: SDE<T, Y>,
+    Method: StochasticNumericalMethod<T, Y> + Interpolation<T, Y>,
+    SoloutType: Solout<T, Y>,
+{
+    fn solve_ivp(self) -> Result<Solution<T, Y>, Error<T, Y>> {
+        self.solve()
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl<'a, const L: usize, F, H, T: Real, Y: State<T>, Method, SoloutType> Solver<T, Y>
+    for IVP<DdeEq<'a, L, F, H>, T, Y, Method, SoloutType>
+where
+    F: DDE<L, T, Y>,
+    H: Fn(T) -> Y + Clone,
+    Method: DelayNumericalMethod<L, T, Y, H> + Interpolation<T, Y>,
+    SoloutType: Solout<T, Y>,
+{
+    fn solve_ivp(self) -> Result<Solution<T, Y>, Error<T, Y>> {
+        self.solve()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,3 +109,5 @@ pub mod utils;
 pub mod derive {
     pub use differential_equations_derive::State;
 }
+#[cfg(feature = "rayon")]
+pub mod parallel;

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -1,0 +1,33 @@
+use rayon::prelude::*;
+
+use crate::error::Error;
+use crate::solution::Solution;
+use crate::traits::{Real, State};
+
+/// Extension trait to solve a collection of IVPs in parallel.
+pub trait ParallelSolve<T, Y>
+where
+    T: Real,
+    Y: State<T>,
+{
+    /// Solves a collection of initial value problems in parallel using `rayon`.
+    fn par_solve(self) -> Vec<Result<Solution<T, Y>, Error<T, Y>>>;
+}
+
+impl<I, T, Y> ParallelSolve<T, Y> for I
+where
+    T: Real + Send,
+    Y: State<T> + Send,
+    I: IntoParallelIterator,
+    I::Item: Solver<T, Y> + Send,
+{
+    fn par_solve(self) -> Vec<Result<Solution<T, Y>, Error<T, Y>>> {
+        self.into_par_iter().map(|ivp| ivp.solve_ivp()).collect()
+    }
+}
+
+/// A trait representing something that can be solved.
+/// This allows us to abstract over the specific IVP types (ODE, DAE, etc.)
+pub trait Solver<T: Real, Y: State<T>> {
+    fn solve_ivp(self) -> Result<Solution<T, Y>, Error<T, Y>>;
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -65,3 +65,5 @@ pub use crate::status::Status;
 
 // Linear Algebra
 pub use crate::linalg::Matrix;
+#[cfg(feature = "rayon")]
+pub use crate::parallel::ParallelSolve;

--- a/tests/dde/accuracy.rs
+++ b/tests/dde/accuracy.rs
@@ -3,8 +3,8 @@
 
 use super::systems::MackeyGlass;
 use differential_equations::ivp::IVP;
-use differential_equations::methods::ExplicitRungeKutta;
 use differential_equations::traits::State;
+use differential_equations::methods::ExplicitRungeKutta;
 use std::fs;
 
 macro_rules! test_dde {

--- a/tests/dde/accuracy.rs
+++ b/tests/dde/accuracy.rs
@@ -3,8 +3,8 @@
 
 use super::systems::MackeyGlass;
 use differential_equations::ivp::IVP;
-use differential_equations::traits::State;
 use differential_equations::methods::ExplicitRungeKutta;
+use differential_equations::traits::State;
 use std::fs;
 
 macro_rules! test_dde {

--- a/tests/parallel.rs
+++ b/tests/parallel.rs
@@ -1,0 +1,104 @@
+#![cfg(feature = "rayon")]
+use differential_equations::parallel::ParallelSolve;
+use differential_equations::prelude::*;
+
+struct TestOde;
+impl ODE for TestOde {
+    fn diff(&self, _t: f64, y: &f64, dydt: &mut f64) {
+        *dydt = -y;
+    }
+}
+
+struct TestDae;
+impl DAE for TestDae {
+    fn diff(&self, _t: f64, y: &f64, f: &mut f64) {
+        *f = -y;
+    }
+    fn mass(&self, m: &mut differential_equations::linalg::Matrix<f64>) {
+        m[(0, 0)] = 1.0;
+    }
+}
+
+struct TestSde {
+    rng: rand::rngs::StdRng,
+}
+use rand::SeedableRng;
+impl TestSde {
+    fn new(seed: u64) -> Self {
+        Self {
+            rng: rand::rngs::StdRng::seed_from_u64(seed),
+        }
+    }
+}
+impl SDE for TestSde {
+    fn drift(&self, _t: f64, y: &f64, dydt: &mut f64) {
+        *dydt = -y;
+    }
+    fn diffusion(&self, _t: f64, y: &f64, dydw: &mut f64) {
+        *dydw = y * 0.1;
+    }
+    fn noise(&mut self, dt: f64, dw: &mut f64) {
+        use rand_distr::{Distribution, Normal};
+        let normal = Normal::new(0.0, dt.sqrt()).unwrap();
+        *dw = normal.sample(&mut self.rng);
+    }
+}
+
+struct TestDde;
+impl DDE<1> for TestDde {
+    fn diff(&self, _t: f64, y: &f64, _dy: &[f64; 1], dydt: &mut f64) {
+        *dydt = -y;
+    }
+    fn lags(&self, _t: f64, _y: &f64, lags: &mut [f64; 1]) {
+        lags[0] = 0.1;
+    }
+}
+
+#[test]
+fn test_parallel_solvers() {
+    let t0 = 0.0;
+    let tf = 1.0;
+    let y0 = 1.0;
+
+    let ode = TestOde;
+    let dae = TestDae;
+    let mut sdes: Vec<_> = (0..10).map(|i| TestSde::new(i)).collect();
+    let dde = TestDde;
+
+    // ODE
+    let mut ode_ivps = Vec::new();
+    for _ in 0..10 {
+        ode_ivps.push(IVP::ode(&ode, t0, tf, y0).method(ExplicitRungeKutta::dop853()));
+    }
+    let ode_results = ode_ivps.par_solve();
+    assert_eq!(ode_results.len(), 10);
+    assert!(ode_results.into_iter().all(|r| r.is_ok()));
+
+    // DAE
+    let mut dae_ivps = Vec::new();
+    for _ in 0..10 {
+        dae_ivps.push(IVP::dae(&dae, t0, tf, y0).method(ImplicitRungeKutta::radau5()));
+    }
+    let dae_results = dae_ivps.par_solve();
+    assert_eq!(dae_results.len(), 10);
+    assert!(dae_results.into_iter().all(|r| r.is_ok()));
+
+    // SDE
+    let sde_ivps: Vec<_> = sdes
+        .iter_mut()
+        .map(|sde| IVP::sde(sde, t0, tf, y0).method(ExplicitRungeKutta::euler(0.01)))
+        .collect();
+    let sde_results = sde_ivps.par_solve();
+    assert_eq!(sde_results.len(), 10);
+    assert!(sde_results.into_iter().all(|r| r.is_ok()));
+
+    // DDE
+    let mut dde_ivps = Vec::new();
+    let history = |_: f64| 1.0;
+    for _ in 0..10 {
+        dde_ivps.push(IVP::dde(&dde, t0, tf, y0, history).method(ExplicitRungeKutta::dop853()));
+    }
+    let dde_results = dde_ivps.par_solve();
+    assert_eq!(dde_results.len(), 10);
+    assert!(dde_results.into_iter().all(|r| r.is_ok()));
+}


### PR DESCRIPTION
🎯 What
Adds helper methods to solve many IVPs (parameter sweeps/Monte Carlo) in parallel across CPU cores using `rayon`.

📊 Coverage
Added a test suite `tests/parallel.rs` to verify that all core solvers (ODE, DAE, SDE, and DDE) can be parallelized natively with `rayon`.

✨ Result
A new `ParallelSolve` extension trait provides the `par_solve` method for iterators of `IVP`s. It avoids modifying core traits with `Send` or `Sync` bounds by relying on Rust's auto-traits, which gracefully propagate through the `IVP` components. An example showcasing a Monte Carlo simulation for Geometric Brownian Motion using the new parallel solver is also included.

---
*PR created automatically by Jules for task [3618549310047833983](https://jules.google.com/task/3618549310047833983) started by @Ryan-D-Gast*