### PR TITLE
docs(core): update documentation for unified event system

### DIFF
--- a/src/dae/dae.rs
+++ b/src/dae/dae.rs
@@ -1,7 +1,6 @@
 //! Defines system of differential algebraic equations for numerical solvers.
 //! The NumericalMethods use this trait to take a input system from the user and solve
-//! Includes differential equations, mass matrix, and optional event function to interrupt solver
-//! given a condition or event.
+//! Includes differential equations and mass matrix. Event handling is provided via the separate `Event` trait.
 
 use crate::{
     linalg::Matrix,
@@ -13,16 +12,11 @@ use crate::{
 /// DAE trait defines the differential algebraic equation system m·y' = f(t, y) for the solver.
 /// Where m is the mass matrix, y is the solution vector, y' is the derivative vector, and
 /// f(t, y) is the right-hand side function. When m is the identity matrix, this reduces
-/// to the standard ODE form y' = f(t, y). The trait also includes an event function to
-/// interrupt the solver when a condition is met or event occurs.
+/// to the standard ODE form y' = f(t, y).
 ///
 /// # Impl
 /// * `diff`  - Right-hand side function f(t, y) in form f(t, &y, &mut f).
 /// * `mass`  - Mass matrix m that multiplies y' in the DAE system m·y' = f(t, y).
-/// * `event` - Event function to interrupt solver when condition is met or event occurs.
-///
-/// Note that the event function is optional and can be left out when implementing
-/// in which case it will be set to return Continue by default.
 pub trait DAE<T = f64, V = DefaultState<T>>
 where
     T: Real,

--- a/src/dae/solve.rs
+++ b/src/dae/solve.rs
@@ -68,9 +68,10 @@ use crate::{
 ///
 /// # Event Handling
 ///
-/// The solver checks for events after each step using the `event` method of the system.
-/// If an event returns `ControlFlag::Terminate`, the integration stops and interpolates
-/// to find the precise point where the event occurred, using a modified regula falsi method.
+/// The solver supports event detection through the `Solout` interface via `EventWrappedSolout`.
+/// You can add an event handler using the `IVP::event()` builder method.
+/// If an event terminates the solver, the integration stops and interpolates
+/// to find the precise point where the event occurred using Brent-Dekker root finding.
 ///
 /// # Notes
 ///

--- a/src/ode/ode.rs
+++ b/src/ode/ode.rs
@@ -1,7 +1,6 @@
 //! Defines system of differential equations for numerical solvers.
 //! The NumericalMethods use this trait to take a input system from the user and solve
-//! Includes a differential equation and optional event function to interupt solver
-//! given a condition or event.
+//! Includes a differential equation. Event handling is provided via the separate `Event` trait.
 
 use crate::{
     linalg::Matrix,
@@ -12,15 +11,12 @@ use crate::{
 ///
 /// ODE trait defines the differential equation dydt = f(t, y) for the solver.
 /// The differential equation is used to solve the ordinary differential equation.
-/// The trait also includes a solout function to interupt the solver when a condition
-/// is met or event occurs.
 ///
 /// # Impl
 /// * `diff`    - Differential Equation dydt = f(t, y) in form f(t, &y, &mut dydt).
-/// * `event`   - Event function to interupt solver when condition is met or event occurs.
 /// * `jacobian` - Jacobian matrix J = df/dy for the system of equations.
 ///
-/// Note that the event and jacobian functions are optional and can be left out when implementing.
+/// Note that the jacobian function is optional and can be left out when implementing.
 pub trait ODE<T = f64, Y = DefaultState<T>>
 where
     T: Real,

--- a/src/ode/solve.rs
+++ b/src/ode/solve.rs
@@ -65,9 +65,10 @@ use crate::{
 ///
 /// # Event Handling
 ///
-/// The solver checks for events after each step using the `event` method of the system.
-/// If an event returns `ControlFlag::Terminate`, the integration stops and interpolates
-/// to find the precise point where the event occurred, using a modified regula falsi method.
+/// The solver supports event detection through the `Solout` interface via `EventWrappedSolout`.
+/// You can add an event handler using the `IVP::event()` builder method.
+/// If an event terminates the solver, the integration stops and interpolates
+/// to find the precise point where the event occurred using Brent-Dekker root finding.
 ///
 /// # Examples
 ///

--- a/src/sde/sde.rs
+++ b/src/sde/sde.rs
@@ -1,7 +1,6 @@
 //! Defines system of stochastic differential equations for numerical solvers.
 //! The NumericalMethods use this trait to take a input system from the user and solve
-//! Includes a stochastic differential equation and optional event function to interupt solver
-//! given a condition or event.
+//! Includes a stochastic differential equation. Event handling is provided via the separate `Event` trait.
 
 use crate::traits::{DefaultState, Real, State};
 
@@ -9,16 +8,11 @@ use crate::traits::{DefaultState, Real, State};
 ///
 /// SDE trait defines the stochastic differential equation dY = a(t,Y)dt + b(t,Y)dW for the solver.
 /// The stochastic differential equation is used to solve systems with both deterministic and random components.
-/// The trait also includes a solout function to interupt the solver when a condition
-/// is met or event occurs.
 ///
 /// # Impl
 /// * `drift`     - Deterministic part a(t,Y) of the SDE in form drift(t, &y, &mut dydt).
 /// * `diffusion` - Stochastic part b(t,Y) of the SDE in form diffusion(t, &y, &mut dydw).
 /// * `noise`     - Generates the random noise increments for the SDE.
-/// * `event`     - Event function to interupt solver when condition is met or event occurs.
-///
-/// Note that the event function is optional and can be left out when implementing.
 pub trait SDE<T = f64, Y = DefaultState<T>>
 where
     T: Real,

--- a/src/sde/solve.rs
+++ b/src/sde/solve.rs
@@ -70,9 +70,10 @@ use crate::{
 ///
 /// # Event Handling
 ///
-/// The solver checks for events after each step using the `event` method of the system.
-/// If an event returns `ControlFlag::Terminate`, the integration stops and interpolates
-/// to find the precise point where the event occurred, using a modified regula falsi method.
+/// The solver supports event detection through the `Solout` interface via `EventWrappedSolout`.
+/// You can add an event handler using the `IVP::event()` builder method.
+/// If an event terminates the solver, the integration stops and interpolates
+/// to find the precise point where the event occurred using Brent-Dekker root finding.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
🎯 **What**
This PR cleans up outdated documentation to align with the newly unified event system across all equation types (ODE, DAE, DDE, SDE). 

Previously, documentation claimed that an `event` method existed on the equation traits themselves. In reality, event handling has been extracted into a separate, unified `Event` trait located in `src/solout/event.rs`, and is implemented universally through the `IVP::event()` builder method by wrapping the `Solout` output strategy.

**Changes:**
- Removed misleading references to an `event` method in the `ODE`, `DAE`, and `SDE` trait descriptions.
- Updated `solve_ode`, `solve_dae`, and `solve_sde` documentation to explicitly direct users to the `Solout` interface and `IVP::event()` builder method for event detection.

📊 **Coverage**
No code logic was altered. Existing unit tests for solvers and event detection were run and passed.

✨ **Result**
Documentation correctly reflects the unified event handling architecture, eliminating confusion for library users.

---
*PR created automatically by Jules for task [15499117721361210861](https://jules.google.com/task/15499117721361210861) started by @Ryan-D-Gast*