### PR TITLE
feat(observability): logging and instrumentation with tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ polars = ["dep:polars"]
 serde = ["dep:serde"]
 ndarray = ["dep:ndarray"]
 faer = ["dep:faer"]
+observability = ["dep:tracing"]
 
 [lints.clippy]
 module_inception = "allow"
@@ -51,6 +52,7 @@ polars = { version = "^0.53.0", optional = true } # DataFrame integration for th
 serde = { version = "1.0.228", features = ["derive"], optional = true } # solution serialization/deserialization
 ndarray = { version = "0.17.2", optional = true }
 faer = { version = "0.24.0", optional = true }
+tracing = { version = "0.1.44", optional = true }
 
 [dev-dependencies]
 quill = "0.2.0" # Plotting for examples
@@ -58,6 +60,7 @@ criterion = { version = "0.8.2", features = ["html_reports"] } # Benchmarking li
 num-dual = "0.13.6" # Dual numbers
 rand = "0.10.0" # Random number generation for SDE examples
 rand_distr = "0.6.0" # Random distributions for SDE examples
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 [[test]]
 name = "ode"
@@ -180,6 +183,11 @@ path = "examples/dde/01_mackey_glass/main.rs"
 [[example]]
 name = "dde_02_breast_cancer_model"
 path = "examples/dde/02_breast_cancer_model/main.rs"
+
+[[example]]
+name = "ode_18_telemetry"
+path = "examples/ode/18_telemetry/main.rs"
+required-features = ["observability"]
 
 # Benchmarks
 [[bench]]

--- a/examples/ode/18_telemetry/main.rs
+++ b/examples/ode/18_telemetry/main.rs
@@ -1,0 +1,43 @@
+//! Example 18: Telemetry and Observability
+//!
+//! This example demonstrates how to use the `tracing` framework with the solvers.
+//! Solvers emit telemetry about step rejections, order changes, and Newton iterations,
+//! allowing for deep insights into solver behavior and debugging.
+
+use differential_equations::prelude::*;
+use tracing_subscriber::{EnvFilter, fmt};
+
+struct StiffODE;
+
+impl ODE for StiffODE {
+    fn diff(&self, t: f64, y: &f64, dydt: &mut f64) {
+        // A moderately stiff ODE: y' = -50 * (y - cos(t)) - sin(t)
+        *dydt = -50.0 * (*y - t.cos()) - t.sin();
+    }
+}
+
+fn main() {
+    // Set up `tracing` to output solver telemetry to standard output
+    // Run this example with `RUST_LOG=trace cargo run --example ode_18_telemetry` to see the output
+    fmt().with_env_filter(EnvFilter::from_default_env()).init();
+
+    tracing::info!("Starting integration of stiff ODE to demonstrate telemetry.");
+
+    let y0 = 0.0;
+    let t0 = 0.0;
+    let tf = 2.0;
+    let ode = StiffODE;
+
+    // We use BDF, an adaptive multi-step solver, which can change order and reject steps
+    let solution = match IVP::ode(&ode, t0, tf, y0)
+        .method(BDF::adaptive().rtol(1e-4).atol(1e-4))
+        .solve()
+    {
+        Ok(solution) => solution,
+        Err(e) => panic!("Error: {:?}", e),
+    };
+
+    tracing::info!("Integration complete.");
+    tracing::info!("Steps accepted: {}", solution.steps.accepted);
+    tracing::info!("Steps rejected: {}", solution.steps.rejected);
+}

--- a/src/dae/solve.rs
+++ b/src/dae/solve.rs
@@ -79,6 +79,10 @@ use crate::{
 /// * The `tf == t0` case is considered an error (no integration to perform).
 /// * The output points depend on the chosen `Solout` implementation.
 ///
+#[cfg_attr(
+    feature = "observability",
+    tracing::instrument(skip_all, name = "solve")
+)]
 pub fn solve_dae<T, V, S, F, O>(
     solver: &mut S,
     dae: &F,

--- a/src/dde/solve.rs
+++ b/src/dde/solve.rs
@@ -61,6 +61,10 @@ use crate::{
 ///   (`Error::StepSizeTooSmall`), exceeding the maximum number of steps (`Error::MaxSteps`),
 ///   or potential stiffness detected by the solver (`Error::Stiffness`).
 ///
+#[cfg_attr(
+    feature = "observability",
+    tracing::instrument(skip_all, name = "solve")
+)]
 pub fn solve_dde<const L: usize, T, Y, S, F, H, O>(
     solver: &mut S,
     dde: &F,

--- a/src/methods/bdf/adaptive.rs
+++ b/src/methods/bdf/adaptive.rs
@@ -9,6 +9,8 @@ use crate::{
     traits::{Real, State},
     utils::{constrain_step_size, validate_step_size_parameters},
 };
+#[cfg(feature = "observability")]
+use tracing::debug;
 
 use super::{BDF, BDF_ROWS, MAX_ORDER};
 
@@ -338,6 +340,12 @@ impl<T: Real, Y: State<T>> OrdinaryNumericalMethod<T, Y> for BDF<Ordinary, T, Y>
             }
 
             if !converged {
+                #[cfg(feature = "observability")]
+                debug!(
+                    t = ?self.t,
+                    h = ?self.h,
+                    "BDF Newton iterations failed to converge, reducing step size"
+                );
                 self.apply_step_factor(order, Self::scalar(0.5));
                 continue;
             }
@@ -349,6 +357,13 @@ impl<T: Real, Y: State<T>> OrdinaryNumericalMethod<T, Y> for BDF<Ordinary, T, Y>
             let error_norm = self.weighted_rms_norm(&error, &scale);
 
             if error_norm > T::one() {
+                #[cfg(feature = "observability")]
+                debug!(
+                    t = ?self.t,
+                    order = ?order,
+                    error_norm = ?error_norm,
+                    "BDF step rejected due to high error norm"
+                );
                 let factor = self
                     .min_scale
                     .max(safety * error_norm.powf(-T::one() / Self::order_scalar(order + 1)));
@@ -407,6 +422,16 @@ impl<T: Real, Y: State<T>> OrdinaryNumericalMethod<T, Y> for BDF<Ordinary, T, Y>
             if higher_factor > best_factor {
                 best_factor = higher_factor;
                 delta_order = 1;
+            }
+
+            if delta_order != 0 {
+                #[cfg(feature = "observability")]
+                debug!(
+                    t = ?self.t,
+                    old_order = ?order,
+                    new_order = ?((order as isize + delta_order) as usize),
+                    "BDF changing order"
+                );
             }
 
             order = (order as isize + delta_order) as usize;

--- a/src/methods/dirk/adaptive/ordinary.rs
+++ b/src/methods/dirk/adaptive/ordinary.rs
@@ -179,6 +179,12 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
 
             // Newton failed for this stage
             if !newton_converged {
+                #[cfg(feature = "observability")]
+                tracing::debug!(
+                    t = ?self.t,
+                    h = ?self.h,
+                    "DIRK stage Newton failed to converge"
+                );
                 // Reduce h and retry later
                 self.h *= T::from_f64(0.25).unwrap();
                 self.h = constrain_step_size(self.h, self.h_min, self.h_max);
@@ -276,6 +282,13 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
             }
         } else {
             // Rejected
+            #[cfg(feature = "observability")]
+            tracing::debug!(
+                t = ?self.t,
+                h = ?self.h,
+                err_norm = ?err_norm,
+                "DIRK adaptive step rejected due to error estimate"
+            );
             self.status = Status::RejectedStep;
             self.stiffness_counter += 1;
 

--- a/src/methods/erk/adaptive/ordinary.rs
+++ b/src/methods/erk/adaptive/ordinary.rs
@@ -181,6 +181,13 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
             }
         } else {
             // Step rejected
+            #[cfg(feature = "observability")]
+            tracing::debug!(
+                t = ?self.t,
+                h = ?self.h,
+                err_norm = ?err_norm,
+                "ERK adaptive step rejected due to error estimate"
+            );
             self.status = Status::RejectedStep;
             self.stiffness_counter += 1;
 

--- a/src/methods/irk/radau/ordinary.rs
+++ b/src/methods/irk/radau/ordinary.rs
@@ -10,6 +10,8 @@ use crate::{
     traits::{Real, State},
     utils::{constrain_step_size, validate_step_size_parameters},
 };
+#[cfg(feature = "observability")]
+use tracing::debug;
 
 impl<T: Real, Y: State<T>> OrdinaryNumericalMethod<T, Y> for Radau5<Ordinary, T, Y> {
     fn init<F>(&mut self, ode: &F, t0: T, tf: T, y0: &Y) -> Result<Evals, Error<T, Y>>
@@ -312,11 +314,25 @@ impl<T: Real, Y: State<T>> OrdinaryNumericalMethod<T, Y> for Radau5<Ordinary, T,
                         self.hhfac = T::from_f64(0.8).unwrap() * qnewt.powf(exponent);
                         self.h *= self.hhfac;
                         self.h = (self.filter)(self.h);
+                        #[cfg(feature = "observability")]
+                        debug!(
+                            t = ?self.t,
+                            h = ?self.h,
+                            theta = ?self.theta,
+                            "Radau5 step rejected due to slow Newton convergence"
+                        );
                         self.status = Status::RejectedStep;
                         self.reject = true;
                         return Ok(evals);
                     }
                 } else {
+                    #[cfg(feature = "observability")]
+                    debug!(
+                        t = ?self.t,
+                        h = ?self.h,
+                        theta = ?self.theta,
+                        "Radau5 step rejected due to Newton divergence"
+                    );
                     self.unexpected_step_rejection();
                     return Ok(evals);
                 }
@@ -482,6 +498,13 @@ impl<T: Real, Y: State<T>> OrdinaryNumericalMethod<T, Y> for Radau5<Ordinary, T,
             self.call_decomp = true;
         } else {
             // Step rejected
+            #[cfg(feature = "observability")]
+            debug!(
+                t = ?self.t,
+                h = ?self.h,
+                err = ?err,
+                "Radau5 step rejected due to error estimate"
+            );
             self.reject = true;
             self.status = Status::RejectedStep;
 

--- a/src/ode/solve.rs
+++ b/src/ode/solve.rs
@@ -112,6 +112,10 @@ use crate::{
 /// * The `tf == t0` case is considered an error (no integration to perform).
 /// * The output points depend on the chosen `Solout` implementation.
 ///
+#[cfg_attr(
+    feature = "observability",
+    tracing::instrument(skip_all, name = "solve")
+)]
 pub fn solve_ode<T, Y, S, F, O>(
     solver: &mut S,
     ode: &F,

--- a/src/sde/solve.rs
+++ b/src/sde/solve.rs
@@ -131,6 +131,10 @@ use crate::{
 /// * The output points depend on the chosen `Solout` implementation.
 /// * Due to the stochastic nature, each run will produce different results unless a specific seed is used.
 ///
+#[cfg_attr(
+    feature = "observability",
+    tracing::instrument(skip_all, name = "solve")
+)]
 pub fn solve_sde<T, Y, S, F, O>(
     solver: &mut S,
     sde: &mut F,

--- a/tests/dde/accuracy.rs
+++ b/tests/dde/accuracy.rs
@@ -3,8 +3,8 @@
 
 use super::systems::MackeyGlass;
 use differential_equations::ivp::IVP;
-use differential_equations::methods::ExplicitRungeKutta;
 use differential_equations::traits::State;
+use differential_equations::methods::ExplicitRungeKutta;
 use std::fs;
 
 macro_rules! test_dde {

--- a/tests/dde/accuracy.rs
+++ b/tests/dde/accuracy.rs
@@ -3,8 +3,8 @@
 
 use super::systems::MackeyGlass;
 use differential_equations::ivp::IVP;
-use differential_equations::traits::State;
 use differential_equations::methods::ExplicitRungeKutta;
+use differential_equations::traits::State;
 use std::fs;
 
 macro_rules! test_dde {


### PR DESCRIPTION
Adds telemetry output for observing solver behaviour:

- Emits `tracing::debug!` logs during step rejections (due to error thresholds or stiffness)
- Emits `tracing::debug!` logs when step sizes/orders are updated (e.g. BDF order adjustments)
- Emits `tracing::debug!` logs during Newton iteration non-convergence failures (e.g. in Radau5, DIRK, and BDF methods)
- Places tracing spans directly on `solve_ode`/`dae`/`dde`/`sde` entrypoints using `tracing::instrument`.
- Protects all tracing functionality behind the `observability` Cargo feature to strictly ensure zero performance impact.
- Exposes `tracing-subscriber` through `dev-dependencies`.
- Included `examples/ode/18_telemetry/main.rs` which demonstrates tracking solver behaviors on a moderately stiff system.

---
*PR created automatically by Jules for task [5648569177444737132](https://jules.google.com/task/5648569177444737132) started by @Ryan-D-Gast*