### PR TITLE
feat(derive): support non-generic State structs

### DIFF
--- a/derive/src/code_generation.rs
+++ b/derive/src/code_generation.rs
@@ -274,46 +274,56 @@ pub fn generate_set_branches(
 pub fn generate_zeros_init(
     fields: &Punctuated<Field, Comma>,
     field_info: &[FieldTypeInfo],
+    scalar_ty: &proc_macro2::TokenStream,
+    zero: &proc_macro2::TokenStream,
 ) -> Vec<proc_macro2::TokenStream> {
-    fields.iter().zip(field_info).map(|(field, field_type)| {
-        match &field.ident {
-            Some(ident) => {
-                match field_type {
-                    FieldTypeInfo::Single => quote! { #ident: T::zero() },
-                    FieldTypeInfo::Array { array_size } => quote! { #ident: [T::zero(); #array_size] },
-                    FieldTypeInfo::SMatrix { rows, cols } => {
-                        let zeros_expr = generate_nalgebra_zeros(*rows, *cols);
-                        quote! { #ident: #zeros_expr }
-                    },
-                    FieldTypeInfo::Complex => quote! { #ident: num_complex::Complex::new(T::zero(), T::zero()) },
-                    FieldTypeInfo::ArrayOfSMatrix { array_size, rows, cols } => {
-                        let zeros_expr = generate_nalgebra_zeros(*rows, *cols);
-                        quote! { #ident: [#zeros_expr; #array_size] }
-                    },
-                    FieldTypeInfo::ArrayOfComplex { array_size } => {
-                        quote! { #ident: [num_complex::Complex::new(T::zero(), T::zero()); #array_size] }
-                    },
+    fields
+        .iter()
+        .zip(field_info)
+        .map(|(field, field_type)| match &field.ident {
+            Some(ident) => match field_type {
+                FieldTypeInfo::Single => quote! { #ident: #zero },
+                FieldTypeInfo::Array { array_size } => quote! { #ident: [#zero; #array_size] },
+                FieldTypeInfo::SMatrix { rows, cols } => {
+                    let zeros_expr = generate_nalgebra_zeros(scalar_ty, *rows, *cols);
+                    quote! { #ident: #zeros_expr }
+                }
+                FieldTypeInfo::Complex => {
+                    quote! { #ident: num_complex::Complex::new(#zero, #zero) }
+                }
+                FieldTypeInfo::ArrayOfSMatrix {
+                    array_size,
+                    rows,
+                    cols,
+                } => {
+                    let zeros_expr = generate_nalgebra_zeros(scalar_ty, *rows, *cols);
+                    quote! { #ident: [#zeros_expr; #array_size] }
+                }
+                FieldTypeInfo::ArrayOfComplex { array_size } => {
+                    quote! { #ident: [num_complex::Complex::new(#zero, #zero); #array_size] }
                 }
             },
-            None => {
-                match field_type {
-                    FieldTypeInfo::Single => quote! { T::zero() },
-                    FieldTypeInfo::Array { array_size } => quote! { [T::zero(); #array_size] },
-                    FieldTypeInfo::SMatrix { rows, cols } => {
-                        generate_nalgebra_zeros(*rows, *cols)
-                    },
-                    FieldTypeInfo::Complex => quote! { num_complex::Complex::new(T::zero(), T::zero()) },
-                    FieldTypeInfo::ArrayOfSMatrix { array_size, rows, cols } => {
-                        let zeros_expr = generate_nalgebra_zeros(*rows, *cols);
-                        quote! { [#zeros_expr; #array_size] }
-                    },
-                    FieldTypeInfo::ArrayOfComplex { array_size } => {
-                        quote! { [num_complex::Complex::new(T::zero(), T::zero()); #array_size] }
-                    },
+            None => match field_type {
+                FieldTypeInfo::Single => quote! { #zero },
+                FieldTypeInfo::Array { array_size } => quote! { [#zero; #array_size] },
+                FieldTypeInfo::SMatrix { rows, cols } => {
+                    generate_nalgebra_zeros(scalar_ty, *rows, *cols)
                 }
-            }
-        }
-    }).collect()
+                FieldTypeInfo::Complex => quote! { num_complex::Complex::new(#zero, #zero) },
+                FieldTypeInfo::ArrayOfSMatrix {
+                    array_size,
+                    rows,
+                    cols,
+                } => {
+                    let zeros_expr = generate_nalgebra_zeros(scalar_ty, *rows, *cols);
+                    quote! { [#zeros_expr; #array_size] }
+                }
+                FieldTypeInfo::ArrayOfComplex { array_size } => {
+                    quote! { [num_complex::Complex::new(#zero, #zero); #array_size] }
+                }
+            },
+        })
+        .collect()
 }
 
 /// Generate debug field implementations

--- a/derive/src/field_analysis.rs
+++ b/derive/src/field_analysis.rs
@@ -122,40 +122,44 @@ pub fn get_nalgebra_dimensions(type_name: &str) -> Option<(usize, usize)> {
 }
 
 /// Generate the appropriate nalgebra constructor for zeros
-pub fn generate_nalgebra_zeros(rows: usize, cols: usize) -> proc_macro2::TokenStream {
+pub fn generate_nalgebra_zeros(
+    scalar_ty: &proc_macro2::TokenStream,
+    rows: usize,
+    cols: usize,
+) -> proc_macro2::TokenStream {
     if cols == 1 {
         // This is a vector, use Vector constructor if available
         match rows {
-            2 => quote! { nalgebra::Vector2::<T>::zeros() },
-            3 => quote! { nalgebra::Vector3::<T>::zeros() },
-            4 => quote! { nalgebra::Vector4::<T>::zeros() },
-            5 => quote! { nalgebra::Vector5::<T>::zeros() },
-            6 => quote! { nalgebra::Vector6::<T>::zeros() },
-            _ => quote! { nalgebra::SMatrix::<T, #rows, #cols>::zeros() },
+            2 => quote! { nalgebra::Vector2::<#scalar_ty>::zeros() },
+            3 => quote! { nalgebra::Vector3::<#scalar_ty>::zeros() },
+            4 => quote! { nalgebra::Vector4::<#scalar_ty>::zeros() },
+            5 => quote! { nalgebra::Vector5::<#scalar_ty>::zeros() },
+            6 => quote! { nalgebra::Vector6::<#scalar_ty>::zeros() },
+            _ => quote! { nalgebra::SMatrix::<#scalar_ty, #rows, #cols>::zeros() },
         }
     } else if rows == 1 {
         // This is a row vector, use RowVector constructor if available
         match cols {
-            2 => quote! { nalgebra::RowVector2::<T>::zeros() },
-            3 => quote! { nalgebra::RowVector3::<T>::zeros() },
-            4 => quote! { nalgebra::RowVector4::<T>::zeros() },
-            5 => quote! { nalgebra::RowVector5::<T>::zeros() },
-            6 => quote! { nalgebra::RowVector6::<T>::zeros() },
-            _ => quote! { nalgebra::SMatrix::<T, #rows, #cols>::zeros() },
+            2 => quote! { nalgebra::RowVector2::<#scalar_ty>::zeros() },
+            3 => quote! { nalgebra::RowVector3::<#scalar_ty>::zeros() },
+            4 => quote! { nalgebra::RowVector4::<#scalar_ty>::zeros() },
+            5 => quote! { nalgebra::RowVector5::<#scalar_ty>::zeros() },
+            6 => quote! { nalgebra::RowVector6::<#scalar_ty>::zeros() },
+            _ => quote! { nalgebra::SMatrix::<#scalar_ty, #rows, #cols>::zeros() },
         }
     } else if rows == cols {
         // This is a square matrix, use Matrix constructor if available
         match rows {
-            2 => quote! { nalgebra::Matrix2::<T>::zeros() },
-            3 => quote! { nalgebra::Matrix3::<T>::zeros() },
-            4 => quote! { nalgebra::Matrix4::<T>::zeros() },
-            5 => quote! { nalgebra::Matrix5::<T>::zeros() },
-            6 => quote! { nalgebra::Matrix6::<T>::zeros() },
-            _ => quote! { nalgebra::SMatrix::<T, #rows, #cols>::zeros() },
+            2 => quote! { nalgebra::Matrix2::<#scalar_ty>::zeros() },
+            3 => quote! { nalgebra::Matrix3::<#scalar_ty>::zeros() },
+            4 => quote! { nalgebra::Matrix4::<#scalar_ty>::zeros() },
+            5 => quote! { nalgebra::Matrix5::<#scalar_ty>::zeros() },
+            6 => quote! { nalgebra::Matrix6::<#scalar_ty>::zeros() },
+            _ => quote! { nalgebra::SMatrix::<#scalar_ty, #rows, #cols>::zeros() },
         }
     } else {
         // General case
-        quote! { nalgebra::SMatrix::<T, #rows, #cols>::zeros() }
+        quote! { nalgebra::SMatrix::<#scalar_ty, #rows, #cols>::zeros() }
     }
 }
 

--- a/derive/src/implementations.rs
+++ b/derive/src/implementations.rs
@@ -4,17 +4,33 @@ use crate::field_analysis::FieldTypeInfo;
 use quote::quote;
 use syn::{Field, Ident, punctuated::Punctuated, token::Comma};
 
+#[derive(Clone)]
+pub struct ImplContext {
+    pub impl_generics: proc_macro2::TokenStream,
+    pub type_generics: proc_macro2::TokenStream,
+    pub where_clause: proc_macro2::TokenStream,
+    pub scalar_ty: proc_macro2::TokenStream,
+    pub zero_expr: proc_macro2::TokenStream,
+}
+
 /// Generate Add trait implementation
 pub fn generate_add_impl(
     name: &Ident,
+    context: &ImplContext,
     fields: &Punctuated<Field, Comma>,
     field_info: &[FieldTypeInfo],
 ) -> proc_macro2::TokenStream {
-    let add_fields = generate_operation_fields(fields, field_info, OperationType::Add);
+    let add_fields = generate_operation_fields(fields, field_info, OperationType::Add, context);
     let constructor = generate_constructor_syntax(&add_fields, fields);
+    let ImplContext {
+        impl_generics,
+        type_generics,
+        where_clause,
+        ..
+    } = context;
 
     quote! {
-        impl<T: differential_equations::traits::Real> std::ops::Add for #name<T> {
+        impl #impl_generics std::ops::Add for #name #type_generics #where_clause {
             type Output = Self;
 
             fn add(self, rhs: Self) -> Self::Output {
@@ -27,14 +43,21 @@ pub fn generate_add_impl(
 /// Generate Sub trait implementation
 pub fn generate_sub_impl(
     name: &Ident,
+    context: &ImplContext,
     fields: &Punctuated<Field, Comma>,
     field_info: &[FieldTypeInfo],
 ) -> proc_macro2::TokenStream {
-    let sub_fields = generate_operation_fields(fields, field_info, OperationType::Sub);
+    let sub_fields = generate_operation_fields(fields, field_info, OperationType::Sub, context);
     let constructor = generate_constructor_syntax(&sub_fields, fields);
+    let ImplContext {
+        impl_generics,
+        type_generics,
+        where_clause,
+        ..
+    } = context;
 
     quote! {
-        impl<T: differential_equations::traits::Real> std::ops::Sub for #name<T> {
+        impl #impl_generics std::ops::Sub for #name #type_generics #where_clause {
             type Output = Self;
 
             fn sub(self, rhs: Self) -> Self::Output {
@@ -47,13 +70,20 @@ pub fn generate_sub_impl(
 /// Generate AddAssign trait implementation
 pub fn generate_add_assign_impl(
     name: &Ident,
+    context: &ImplContext,
     fields: &Punctuated<Field, Comma>,
     field_info: &[FieldTypeInfo],
 ) -> proc_macro2::TokenStream {
     let add_assign_ops = generate_assign_operations(fields, field_info);
+    let ImplContext {
+        impl_generics,
+        type_generics,
+        where_clause,
+        ..
+    } = context;
 
     quote! {
-        impl<T: differential_equations::traits::Real> std::ops::AddAssign for #name<T> {
+        impl #impl_generics std::ops::AddAssign for #name #type_generics #where_clause {
             fn add_assign(&mut self, rhs: Self) {
                 #(#add_assign_ops)*
             }
@@ -64,17 +94,25 @@ pub fn generate_add_assign_impl(
 /// Generate Mul<T> trait implementation
 pub fn generate_mul_impl(
     name: &Ident,
+    context: &ImplContext,
     fields: &Punctuated<Field, Comma>,
     field_info: &[FieldTypeInfo],
 ) -> proc_macro2::TokenStream {
-    let mul_fields = generate_operation_fields(fields, field_info, OperationType::Mul);
+    let mul_fields = generate_operation_fields(fields, field_info, OperationType::Mul, context);
     let constructor = generate_constructor_syntax(&mul_fields, fields);
+    let ImplContext {
+        impl_generics,
+        type_generics,
+        where_clause,
+        scalar_ty,
+        ..
+    } = context;
 
     quote! {
-        impl<T: differential_equations::traits::Real> std::ops::Mul<T> for #name<T> {
+        impl #impl_generics std::ops::Mul<#scalar_ty> for #name #type_generics #where_clause {
             type Output = Self;
 
-            fn mul(self, rhs: T) -> Self::Output {
+            fn mul(self, rhs: #scalar_ty) -> Self::Output {
                 #constructor
             }
         }
@@ -84,17 +122,25 @@ pub fn generate_mul_impl(
 /// Generate Div<T> trait implementation
 pub fn generate_div_impl(
     name: &Ident,
+    context: &ImplContext,
     fields: &Punctuated<Field, Comma>,
     field_info: &[FieldTypeInfo],
 ) -> proc_macro2::TokenStream {
-    let div_fields = generate_operation_fields(fields, field_info, OperationType::Div);
+    let div_fields = generate_operation_fields(fields, field_info, OperationType::Div, context);
     let constructor = generate_constructor_syntax(&div_fields, fields);
+    let ImplContext {
+        impl_generics,
+        type_generics,
+        where_clause,
+        scalar_ty,
+        ..
+    } = context;
 
     quote! {
-        impl<T: differential_equations::traits::Real> std::ops::Div<T> for #name<T> {
+        impl #impl_generics std::ops::Div<#scalar_ty> for #name #type_generics #where_clause {
             type Output = Self;
 
-            fn div(self, rhs: T) -> Self::Output {
+            fn div(self, rhs: #scalar_ty) -> Self::Output {
                 #constructor
             }
         }
@@ -102,9 +148,16 @@ pub fn generate_div_impl(
 }
 
 /// Generate Clone trait implementation
-pub fn generate_clone_impl(name: &Ident) -> proc_macro2::TokenStream {
+pub fn generate_clone_impl(name: &Ident, context: &ImplContext) -> proc_macro2::TokenStream {
+    let ImplContext {
+        impl_generics,
+        type_generics,
+        where_clause,
+        ..
+    } = context;
+
     quote! {
-        impl<T: differential_equations::traits::Real> Clone for #name<T> {
+        impl #impl_generics Clone for #name #type_generics #where_clause {
             fn clone(&self) -> Self {
                 *self
             }
@@ -113,19 +166,34 @@ pub fn generate_clone_impl(name: &Ident) -> proc_macro2::TokenStream {
 }
 
 /// Generate Copy trait implementation
-pub fn generate_copy_impl(name: &Ident) -> proc_macro2::TokenStream {
+pub fn generate_copy_impl(name: &Ident, context: &ImplContext) -> proc_macro2::TokenStream {
+    let ImplContext {
+        impl_generics,
+        type_generics,
+        where_clause,
+        ..
+    } = context;
+
     quote! {
-        impl<T: differential_equations::traits::Real> Copy for #name<T> {}
+        impl #impl_generics Copy for #name #type_generics #where_clause {}
     }
 }
 
 /// Generate Debug trait implementation
 pub fn generate_debug_impl(
     name: &Ident,
+    context: &ImplContext,
     debug_fields: &[proc_macro2::TokenStream],
 ) -> proc_macro2::TokenStream {
+    let ImplContext {
+        impl_generics,
+        type_generics,
+        where_clause,
+        ..
+    } = context;
+
     quote! {
-        impl<T: differential_equations::traits::Real + std::fmt::Debug> std::fmt::Debug for #name<T> {
+        impl #impl_generics std::fmt::Debug for #name #type_generics #where_clause {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 f.debug_struct(stringify!(#name))
                     #(#debug_fields)*
@@ -138,6 +206,7 @@ pub fn generate_debug_impl(
 /// Generate State trait implementation
 pub fn generate_state_impl(
     name: &Ident,
+    context: &ImplContext,
     total_elements: usize,
     field_get_branches: &[proc_macro2::TokenStream],
     field_set_branches: &[proc_macro2::TokenStream],
@@ -145,24 +214,32 @@ pub fn generate_state_impl(
     fields: &Punctuated<Field, Comma>,
 ) -> proc_macro2::TokenStream {
     let zeros_constructor = generate_constructor_syntax(zeros_init, fields);
+    let ImplContext {
+        impl_generics,
+        type_generics,
+        where_clause,
+        scalar_ty,
+        zero_expr,
+    } = context;
+    let zero = zero_expr;
 
     quote! {
-        impl<T: differential_equations::traits::Real> differential_equations::traits::State<T> for #name<T> {
+        impl #impl_generics differential_equations::traits::State<#scalar_ty> for #name #type_generics #where_clause {
             fn len(&self) -> usize {
                 #total_elements
             }
 
-            fn get_component(&self, index: usize) -> T {
+            fn get_component(&self, index: usize) -> #scalar_ty {
                 self.__state_get(index)
             }
 
-            fn set_component(&mut self, index: usize, value: T) {
+            fn set_component(&mut self, index: usize, value: #scalar_ty) {
                 self.__state_set(index, value);
             }
 
             fn map_components_mut<F>(&mut self, mut f: F)
             where
-                F: FnMut(usize, &mut T),
+                F: FnMut(usize, &mut #scalar_ty),
             {
                 // This is a bit tricky for a struct with named fields if we don't have a way to get a &mut T by index.
                 // However, the macro generates __state_set which we can use with __state_get.
@@ -183,7 +260,7 @@ pub fn generate_state_impl(
                 #zeros_constructor
             }
 
-            fn mul_add_assign(&mut self, alpha: T, other: &Self) {
+            fn mul_add_assign(&mut self, alpha: #scalar_ty, other: &Self) {
                 assert_eq!(self.len(), other.len(), "State length mismatch");
                 for i in 0..self.len() {
                     let value = self.__state_get(i) + alpha * other.__state_get(i);
@@ -191,14 +268,14 @@ pub fn generate_state_impl(
                 }
             }
 
-            fn scale_mut(&mut self, alpha: T) {
+            fn scale_mut(&mut self, alpha: #scalar_ty) {
                 for i in 0..self.len() {
                     let value = self.__state_get(i) * alpha;
                     self.__state_set(i, value);
                 }
             }
 
-            fn fill(&mut self, value: T) {
+            fn fill(&mut self, value: #scalar_ty) {
                 for i in 0..self.len() {
                     self.__state_set(i, value);
                 }
@@ -210,8 +287,8 @@ pub fn generate_state_impl(
                 }
             }
 
-            fn norm_squared(&self) -> T {
-                let mut sum = T::zero();
+            fn norm_squared(&self) -> #scalar_ty {
+                let mut sum = #zero;
                 for i in 0..self.len() {
                     let value = self.__state_get(i);
                     sum += value * value;
@@ -219,8 +296,8 @@ pub fn generate_state_impl(
                 sum
             }
 
-            fn diff_norm_squared(&self, other: &Self) -> T {
-                let mut sum = T::zero();
+            fn diff_norm_squared(&self, other: &Self) -> #scalar_ty {
+                let mut sum = #zero;
                 for i in 0..self.len() {
                     let diff = self.__state_get(i) - other.__state_get(i);
                     sum += diff * diff;
@@ -232,10 +309,10 @@ pub fn generate_state_impl(
                 &self,
                 y_new: &Self,
                 err: &Self,
-                atol: &differential_equations::tolerance::Tolerance<T>,
-                rtol: &differential_equations::tolerance::Tolerance<T>,
-            ) -> T {
-                let mut sum = T::zero();
+                atol: &differential_equations::tolerance::Tolerance<#scalar_ty>,
+                rtol: &differential_equations::tolerance::Tolerance<#scalar_ty>,
+            ) -> #scalar_ty {
+                let mut sum = #zero;
                 for i in 0..self.len() {
                     let sk = atol[i] + rtol[i] * self.__state_get(i).abs().max(y_new.__state_get(i).abs());
                     let e = err.__state_get(i) / sk;
@@ -248,10 +325,10 @@ pub fn generate_state_impl(
                 &self,
                 y_new: &Self,
                 err: &Self,
-                atol: &differential_equations::tolerance::Tolerance<T>,
-                rtol: &differential_equations::tolerance::Tolerance<T>,
-            ) -> T {
-                let mut max = T::zero();
+                atol: &differential_equations::tolerance::Tolerance<#scalar_ty>,
+                rtol: &differential_equations::tolerance::Tolerance<#scalar_ty>,
+            ) -> #scalar_ty {
+                let mut max = #zero;
                 for i in 0..self.len() {
                     let sk = atol[i] + rtol[i] * self.__state_get(i).abs().max(y_new.__state_get(i).abs());
                     max = max.max((err.__state_get(i) / sk).abs());
@@ -260,14 +337,14 @@ pub fn generate_state_impl(
             }
         }
 
-        impl<T: differential_equations::traits::Real> #name<T> {
-            fn __state_get(&self, i: usize) -> T {
+        impl #impl_generics #name #type_generics #where_clause {
+            fn __state_get(&self, i: usize) -> #scalar_ty {
                 assert!(i < #total_elements, "Index out of bounds");
                 #(#field_get_branches)*
                 unreachable!()
             }
 
-            fn __state_set(&mut self, i: usize, value: T) {
+            fn __state_set(&mut self, i: usize, value: #scalar_ty) {
                 assert!(i < #total_elements, "Index out of bounds");
                 #(#field_set_branches)*
                 unreachable!();
@@ -287,14 +364,21 @@ enum OperationType {
 /// Generate Neg trait implementation (unary minus)
 pub fn generate_neg_impl(
     name: &Ident,
+    context: &ImplContext,
     fields: &Punctuated<Field, Comma>,
     field_info: &[FieldTypeInfo],
 ) -> proc_macro2::TokenStream {
-    let neg_fields = generate_neg_fields(fields, field_info);
+    let neg_fields = generate_neg_fields(fields, field_info, context);
     let constructor = generate_constructor_syntax(&neg_fields, fields);
+    let ImplContext {
+        impl_generics,
+        type_generics,
+        where_clause,
+        ..
+    } = context;
 
     quote! {
-        impl<T: differential_equations::traits::Real> std::ops::Neg for #name<T> {
+        impl #impl_generics std::ops::Neg for #name #type_generics #where_clause {
             type Output = Self;
 
             fn neg(self) -> Self::Output {
@@ -308,7 +392,10 @@ pub fn generate_neg_impl(
 fn generate_neg_fields(
     fields: &Punctuated<Field, Comma>,
     field_info: &[FieldTypeInfo],
+    context: &ImplContext,
 ) -> Vec<proc_macro2::TokenStream> {
+    let zero = &context.zero_expr;
+
     fields
         .iter()
         .enumerate()
@@ -319,7 +406,7 @@ fn generate_neg_fields(
                 FieldTypeInfo::Array { array_size } => {
                     quote! {
                         #ident: {
-                            let mut result = [T::zero(); #array_size];
+                            let mut result = [#zero; #array_size];
                             for i in 0..#array_size { result[i] = -self.#ident[i]; }
                             result
                         }
@@ -353,7 +440,7 @@ fn generate_neg_fields(
                     FieldTypeInfo::Array { array_size } => {
                         quote! {
                             {
-                                let mut result = [T::zero(); #array_size];
+                                let mut result = [#zero; #array_size];
                                 for i in 0..#array_size { result[i] = -self.#index[i]; }
                                 result
                             }
@@ -417,7 +504,10 @@ fn generate_operation_fields(
     fields: &Punctuated<Field, Comma>,
     field_info: &[FieldTypeInfo],
     op_type: OperationType,
+    context: &ImplContext,
 ) -> Vec<proc_macro2::TokenStream> {
+    let zero = &context.zero_expr;
+
     fields
         .iter()
         .enumerate()
@@ -444,7 +534,7 @@ fn generate_operation_fields(
                         OperationType::Add | OperationType::Sub => {
                             quote! {
                                 #ident: {
-                                    let mut result = [T::zero(); #array_size];
+                                    let mut result = [#zero; #array_size];
                                     for i in 0..#array_size {
                                         result[i] = #lhs.#ident[i] #op_symbol #rhs.#ident[i];
                                     }
@@ -455,7 +545,7 @@ fn generate_operation_fields(
                         OperationType::Mul | OperationType::Div => {
                             quote! {
                                 #ident: {
-                                    let mut result = [T::zero(); #array_size];
+                                    let mut result = [#zero; #array_size];
                                     for i in 0..#array_size {
                                         result[i] = #lhs.#ident[i] #op_symbol #rhs;
                                     }
@@ -544,7 +634,7 @@ fn generate_operation_fields(
                             OperationType::Add | OperationType::Sub => {
                                 quote! {
                                     {
-                                        let mut result = [T::zero(); #array_size];
+                                        let mut result = [#zero; #array_size];
                                         for i in 0..#array_size {
                                             result[i] = #lhs.#index[i] #op_symbol #rhs.#index[i];
                                         }
@@ -555,7 +645,7 @@ fn generate_operation_fields(
                             OperationType::Mul | OperationType::Div => {
                                 quote! {
                                     {
-                                        let mut result = [T::zero(); #array_size];
+                                        let mut result = [#zero; #array_size];
                                         for i in 0..#array_size {
                                             result[i] = #lhs.#index[i] #op_symbol #rhs;
                                         }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -22,7 +22,10 @@
 //! ```
 
 use proc_macro::TokenStream;
-use syn::{Data, DeriveInput, Fields, parse_macro_input};
+use syn::{
+    Data, DeriveInput, Fields, GenericArgument, PathArguments, Type, TypeArray, TypePath,
+    parse_macro_input, parse_quote,
+};
 
 mod code_generation;
 mod field_analysis;
@@ -30,7 +33,7 @@ mod implementations;
 
 use code_generation::*;
 use field_analysis::analyze_field_type;
-use implementations::*;
+use implementations::{ImplContext, *};
 
 /// Derive macro for the `State` trait.
 ///
@@ -68,8 +71,10 @@ pub fn derive_state(input: TokenStream) -> TokenStream {
     // Parse the input tokens into a syntax tree
     let input = parse_macro_input!(input as DeriveInput);
 
-    // Get the struct name
+    // Get the struct name and implementation target.
     let name = input.ident;
+    let mut generics = input.generics;
+    let has_generic_t = generics.type_params().any(|param| param.ident == "T");
 
     // Extract field information
     let fields = match input.data {
@@ -79,6 +84,30 @@ pub fn derive_state(input: TokenStream) -> TokenStream {
             Fields::Unit => panic!("Unit structs are not supported"),
         },
         _ => panic!("State can only be derived for structs"),
+    };
+
+    let (scalar_ty, zero_expr) = if has_generic_t {
+        for param in generics.type_params_mut() {
+            if param.ident == "T" {
+                param
+                    .bounds
+                    .push(parse_quote!(differential_equations::traits::Real));
+            }
+        }
+        (quote::quote! { T }, quote::quote! { T::zero() })
+    } else {
+        let scalar_ty = infer_scalar_type(&fields)
+            .unwrap_or_else(|| panic!("State derive requires at least one scalar field"));
+        (scalar_ty.clone(), quote::quote! { 0.0 as #scalar_ty })
+    };
+
+    let (impl_generics, type_generics, where_clause) = generics.split_for_impl();
+    let context = ImplContext {
+        impl_generics: quote::quote! { #impl_generics },
+        type_generics: quote::quote! { #type_generics },
+        where_clause: quote::quote! { #where_clause },
+        scalar_ty,
+        zero_expr,
     };
 
     // Analyze field types and calculate total element count
@@ -94,27 +123,29 @@ pub fn derive_state(input: TokenStream) -> TokenStream {
     // Generate all the required components
     let field_get_branches = generate_get_branches(&fields, &field_info);
     let field_set_branches = generate_set_branches(&fields, &field_info);
-    let zeros_init = generate_zeros_init(&fields, &field_info);
+    let zeros_init =
+        generate_zeros_init(&fields, &field_info, &context.scalar_ty, &context.zero_expr);
     let debug_fields = generate_debug_fields(&fields);
 
     // Generate all trait implementations
-    let clone_impl = generate_clone_impl(&name);
-    let copy_impl = generate_copy_impl(&name);
-    let debug_impl = generate_debug_impl(&name, &debug_fields);
+    let clone_impl = generate_clone_impl(&name, &context);
+    let copy_impl = generate_copy_impl(&name, &context);
+    let debug_impl = generate_debug_impl(&name, &context, &debug_fields);
     let state_impl = generate_state_impl(
         &name,
+        &context,
         total_elements,
         &field_get_branches,
         &field_set_branches,
         &zeros_init,
         &fields,
     );
-    let add_impl = generate_add_impl(&name, &fields, &field_info);
-    let sub_impl = generate_sub_impl(&name, &fields, &field_info);
-    let add_assign_impl = generate_add_assign_impl(&name, &fields, &field_info);
-    let neg_impl = generate_neg_impl(&name, &fields, &field_info);
-    let mul_impl = generate_mul_impl(&name, &fields, &field_info);
-    let div_impl = generate_div_impl(&name, &fields, &field_info);
+    let add_impl = generate_add_impl(&name, &context, &fields, &field_info);
+    let sub_impl = generate_sub_impl(&name, &context, &fields, &field_info);
+    let add_assign_impl = generate_add_assign_impl(&name, &context, &fields, &field_info);
+    let neg_impl = generate_neg_impl(&name, &context, &fields, &field_info);
+    let mul_impl = generate_mul_impl(&name, &context, &fields, &field_info);
+    let div_impl = generate_div_impl(&name, &context, &fields, &field_info);
 
     // Combine all implementations
     let expanded = quote::quote! {
@@ -132,4 +163,35 @@ pub fn derive_state(input: TokenStream) -> TokenStream {
 
     // Return the generated implementation
     TokenStream::from(expanded)
+}
+
+fn infer_scalar_type(
+    fields: &syn::punctuated::Punctuated<syn::Field, syn::token::Comma>,
+) -> Option<proc_macro2::TokenStream> {
+    fields
+        .iter()
+        .find_map(|field| infer_scalar_from_type(&field.ty))
+}
+
+fn infer_scalar_from_type(ty: &Type) -> Option<proc_macro2::TokenStream> {
+    match ty {
+        Type::Array(TypeArray { elem, .. }) => infer_scalar_from_type(elem),
+        Type::Path(TypePath { path, .. }) => {
+            let segment = path.segments.last()?;
+            let type_name = segment.ident.to_string();
+
+            if (matches!(type_name.as_str(), "SMatrix" | "Complex")
+                || field_analysis::get_nalgebra_dimensions(&type_name).is_some())
+                && let PathArguments::AngleBracketed(args) = &segment.arguments
+            {
+                return args.args.iter().find_map(|arg| match arg {
+                    GenericArgument::Type(ty) => Some(quote::quote! { #ty }),
+                    _ => None,
+                });
+            }
+
+            Some(quote::quote! { #ty })
+        }
+        _ => None,
+    }
 }

--- a/derive/tests/basic_tests.rs
+++ b/derive/tests/basic_tests.rs
@@ -88,6 +88,56 @@ fn test_multiple_single_fields() {
 }
 
 #[test]
+fn test_non_generic_named_state() {
+    #[derive(State, PartialEq)]
+    struct ConcreteState {
+        x: f64,
+        y: f64,
+        velocity: [f64; 2],
+    }
+
+    let mut state = ConcreteState {
+        x: 1.0,
+        y: 2.0,
+        velocity: [3.0, 4.0],
+    };
+    test_state_basics(&mut state, 4);
+
+    let other = ConcreteState {
+        x: 0.5,
+        y: 1.5,
+        velocity: [2.0, 3.0],
+    };
+    let sum = state + other;
+    assert_eq!(sum.x, 1.5);
+    assert_eq!(sum.y, 3.5);
+    assert_eq!(sum.velocity, [5.0, 7.0]);
+
+    let scaled = sum * 2.0;
+    assert_eq!(scaled.x, 3.0);
+    assert_eq!(scaled.y, 7.0);
+    assert_eq!(scaled.velocity, [10.0, 14.0]);
+
+    let zero = ConcreteState::zeros();
+    assert_eq!(zero.x, 0.0);
+    assert_eq!(zero.y, 0.0);
+    assert_eq!(zero.velocity, [0.0, 0.0]);
+}
+
+#[test]
+fn test_non_generic_tuple_state() {
+    #[derive(State, PartialEq)]
+    struct ConcreteTuple(f64, [f64; 2]);
+
+    let mut state = ConcreteTuple(1.0, [2.0, 3.0]);
+    test_state_basics(&mut state, 3);
+
+    let difference = state - ConcreteTuple(1.0, [1.0, 1.0]);
+    assert_eq!(difference.0, 0.0);
+    assert_eq!(difference.1, [1.0, 2.0]);
+}
+
+#[test]
 fn test_array_fields_only() {
     #[derive(State)]
     struct ArrayFields<T> {


### PR DESCRIPTION
## Summary
- Allows `#[derive(State)]` to generate impls for both `Foo<T>` and concrete structs like `Foo`.
- Infers the scalar type for non-generic structs from scalar, array, nalgebra, or complex fields.
- Adds derive tests for non-generic named and tuple structs.

Closes #91

## Verification
- `cargo test --manifest-path derive/Cargo.toml`
- `cargo clippy --manifest-path derive/Cargo.toml -- -D warnings`