### PR TITLE
Relax `Sized` bounds where possible

### DIFF
--- a/examples/ode/10_custom_solout/main.rs
+++ b/examples/ode/10_custom_solout/main.rs
@@ -99,7 +99,7 @@ impl Solout<f64, [f64; 2]> for PendulumSolout {
         solution: &mut Solution<f64, [f64; 2]>,
     ) -> ControlFlag<f64, [f64; 2]>
     where
-        I: Interpolation<f64, [f64; 2]>,
+        I: Interpolation<f64, [f64; 2]> + ?Sized,
     {
         let current_angle = y_curr[0];
         let dt = t_curr - self.last_output_time;

--- a/src/dae/numerical_method.rs
+++ b/src/dae/numerical_method.rs
@@ -33,7 +33,7 @@ where
     ///
     fn init<F>(&mut self, dae: &F, t0: T, tf: T, y0: &V) -> Result<Evals, Error<T, V>>
     where
-        F: DAE<T, V>;
+        F: DAE<T, V> + ?Sized;
 
     /// Step through solving the DAE by one step
     ///
@@ -45,7 +45,7 @@ where
     ///
     fn step<F>(&mut self, dae: &F) -> Result<Evals, Error<T, V>>
     where
-        F: DAE<T, V>;
+        F: DAE<T, V> + ?Sized;
 
     // Access fields of the solver
 

--- a/src/dae/solve.rs
+++ b/src/dae/solve.rs
@@ -91,8 +91,8 @@ pub fn solve_dae<T, V, S, F, O>(
 where
     T: Real,
     V: State<T>,
-    F: DAE<T, V>,
-    S: AlgebraicNumericalMethod<T, V> + Interpolation<T, V>,
+    F: DAE<T, V> + ?Sized,
+    S: AlgebraicNumericalMethod<T, V> + Interpolation<T, V> + ?Sized,
     O: Solout<T, V>,
 {
     // Initialize the Solution object

--- a/src/dde/numerical_method.rs
+++ b/src/dde/numerical_method.rs
@@ -31,7 +31,7 @@ where
     ///
     fn init<F>(&mut self, dde: &F, t0: T, tf: T, y0: &Y, phi: &H) -> Result<Evals, Error<T, Y>>
     where
-        F: DDE<L, T, Y>;
+        F: DDE<L, T, Y> + ?Sized;
 
     /// Advance the solution by one step
     ///
@@ -43,7 +43,7 @@ where
     ///
     fn step<F>(&mut self, dde: &F, phi: &H) -> Result<Evals, Error<T, Y>>
     where
-        F: DDE<L, T, Y>;
+        F: DDE<L, T, Y> + ?Sized;
 
     // Accessors
 

--- a/src/dde/solve.rs
+++ b/src/dde/solve.rs
@@ -73,10 +73,10 @@ pub fn solve_dde<const L: usize, T, Y, S, F, H, O>(
 where
     T: Real,
     Y: State<T>,
-    F: DDE<L, T, Y>,
+    F: DDE<L, T, Y> + ?Sized,
     H: Fn(T) -> Y + Clone,
-    S: DelayNumericalMethod<L, T, Y, H> + Interpolation<T, Y>,
-    O: Solout<T, Y>,
+    S: DelayNumericalMethod<L, T, Y, H> + Interpolation<T, Y> + ?Sized,
+    O: Solout<T, Y> + ?Sized,
 {
     // Initialize the Solution object
     let mut solution = Solution::new();

--- a/src/ivp.rs
+++ b/src/ivp.rs
@@ -473,7 +473,7 @@ impl<EqType, T: Real, Y: State<T>, Method, SoloutType> IVP<EqType, T, Y, Method,
         event: &'a E,
     ) -> IVP<EqType, T, Y, Method, EventWrappedSolout<'a, T, Y, SoloutType, E>>
     where
-        E: Event<T, Y>,
+        E: Event<T, Y> + ?Sized,
         SoloutType: Solout<T, Y>,
     {
         IVP {

--- a/src/methods/apc/apcf4.rs
+++ b/src/methods/apc/apcf4.rs
@@ -66,7 +66,7 @@ impl<T: Real, Y: State<T>> OrdinaryNumericalMethod<T, Y>
 {
     fn init<F>(&mut self, ode: &F, t0: T, tf: T, y0: &Y) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 
@@ -134,7 +134,7 @@ impl<T: Real, Y: State<T>> OrdinaryNumericalMethod<T, Y>
 
     fn step<F>(&mut self, ode: &F) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 

--- a/src/methods/apc/apcv4.rs
+++ b/src/methods/apc/apcv4.rs
@@ -64,7 +64,7 @@ impl<T: Real, Y: State<T>> AdamsPredictorCorrector<Ordinary, Adaptive, T, Y, 4> 
 
     fn rk4_step<F>(ode: &F, t: &mut T, y: &mut Y, h: T, k: &mut [Y; 4]) -> usize
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let two = T::from_f64(2.0).unwrap();
         let six = T::from_f64(6.0).unwrap();
@@ -89,7 +89,7 @@ impl<T: Real, Y: State<T>> OrdinaryNumericalMethod<T, Y>
 {
     fn init<F>(&mut self, ode: &F, t0: T, tf: T, y0: &Y) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 
@@ -144,7 +144,7 @@ impl<T: Real, Y: State<T>> OrdinaryNumericalMethod<T, Y>
 
     fn step<F>(&mut self, ode: &F) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 

--- a/src/methods/bdf/adaptive.rs
+++ b/src/methods/bdf/adaptive.rs
@@ -146,7 +146,7 @@ impl<T: Real, Y: State<T>> BackwardDifferentiationFormula<Ordinary, T, Y> {
         evals: &mut Evals,
     ) -> (bool, usize, Y, Y)
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut d = self.y.zeros_like();
         let mut y = y_predict;
@@ -207,7 +207,7 @@ impl<T: Real, Y: State<T>> BackwardDifferentiationFormula<Ordinary, T, Y> {
 impl<T: Real, Y: State<T>> OrdinaryNumericalMethod<T, Y> for BackwardDifferentiationFormula<Ordinary, T, Y> {
     fn init<F>(&mut self, ode: &F, t0: T, tf: T, y0: &Y) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 
@@ -256,7 +256,7 @@ impl<T: Real, Y: State<T>> OrdinaryNumericalMethod<T, Y> for BackwardDifferentia
 
     fn step<F>(&mut self, ode: &F) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 

--- a/src/methods/dirk/adaptive/ordinary.rs
+++ b/src/methods/dirk/adaptive/ordinary.rs
@@ -18,7 +18,7 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
 {
     fn init<F>(&mut self, ode: &F, t0: T, tf: T, y0: &Y) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 
@@ -75,7 +75,7 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
 
     fn step<F>(&mut self, ode: &F) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 

--- a/src/methods/dirk/fixed/ordinary.rs
+++ b/src/methods/dirk/fixed/ordinary.rs
@@ -17,7 +17,7 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
 {
     fn init<F>(&mut self, ode: &F, t0: T, tf: T, y0: &Y) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 
@@ -65,7 +65,7 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
 
     fn step<F>(&mut self, ode: &F) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 

--- a/src/methods/erk/adaptive/delay.rs
+++ b/src/methods/erk/adaptive/delay.rs
@@ -24,7 +24,7 @@ impl<
 {
     fn init<F>(&mut self, dde: &F, t0: T, tf: T, y0: &Y, phi: &H) -> Result<Evals, Error<T, Y>>
     where
-        F: DDE<L, T, Y>,
+        F: DDE<L, T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 
@@ -96,7 +96,7 @@ impl<
 
     fn step<F>(&mut self, dde: &F, phi: &H) -> Result<Evals, Error<T, Y>>
     where
-        F: DDE<L, T, Y>,
+        F: DDE<L, T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 

--- a/src/methods/erk/adaptive/ordinary.rs
+++ b/src/methods/erk/adaptive/ordinary.rs
@@ -15,7 +15,7 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
 {
     fn init<F>(&mut self, ode: &F, t0: T, tf: T, y0: &Y) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 
@@ -62,7 +62,7 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
 
     fn step<F>(&mut self, ode: &F) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 

--- a/src/methods/erk/dormandprince/delay.rs
+++ b/src/methods/erk/dormandprince/delay.rs
@@ -24,7 +24,7 @@ impl<
 {
     fn init<F>(&mut self, dde: &F, t0: T, tf: T, y0: &Y, phi: &H) -> Result<Evals, Error<T, Y>>
     where
-        F: DDE<L, T, Y>,
+        F: DDE<L, T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 
@@ -95,7 +95,7 @@ impl<
 
     fn step<F>(&mut self, dde: &F, phi: &H) -> Result<Evals, Error<T, Y>>
     where
-        F: DDE<L, T, Y>,
+        F: DDE<L, T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 

--- a/src/methods/erk/dormandprince/ordinary.rs
+++ b/src/methods/erk/dormandprince/ordinary.rs
@@ -15,7 +15,7 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
 {
     fn init<F>(&mut self, ode: &F, t0: T, tf: T, y0: &Y) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 
@@ -62,7 +62,7 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
 
     fn step<F>(&mut self, ode: &F) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 

--- a/src/methods/erk/fixed/delay.rs
+++ b/src/methods/erk/fixed/delay.rs
@@ -24,7 +24,7 @@ impl<
 {
     fn init<F>(&mut self, dde: &F, t0: T, tf: T, y0: &Y, phi: &H) -> Result<Evals, Error<T, Y>>
     where
-        F: DDE<L, T, Y>,
+        F: DDE<L, T, Y> + ?Sized,
     {
         // Initialize solver state
         let mut evals = Evals::new();
@@ -91,7 +91,7 @@ impl<
 
     fn step<F>(&mut self, dde: &F, phi: &H) -> Result<Evals, Error<T, Y>>
     where
-        F: DDE<L, T, Y>,
+        F: DDE<L, T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 

--- a/src/methods/erk/fixed/ordinary.rs
+++ b/src/methods/erk/fixed/ordinary.rs
@@ -15,7 +15,7 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
 {
     fn init<F>(&mut self, ode: &F, t0: T, tf: T, y0: &Y) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 
@@ -57,7 +57,7 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
 
     fn step<F>(&mut self, ode: &F) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 

--- a/src/methods/erk/fixed/stochastic.rs
+++ b/src/methods/erk/fixed/stochastic.rs
@@ -17,7 +17,7 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
 {
     fn init<F>(&mut self, sde: &mut F, t0: T, tf: T, y0: &Y) -> Result<Evals, Error<T, Y>>
     where
-        F: SDE<T, Y>,
+        F: SDE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 
@@ -66,7 +66,7 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
 
     fn step<F>(&mut self, sde: &mut F) -> Result<Evals, Error<T, Y>>
     where
-        F: SDE<T, Y>,
+        F: SDE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 

--- a/src/methods/h_init.rs
+++ b/src/methods/h_init.rs
@@ -57,7 +57,7 @@ impl InitialStepSize<Ordinary> {
     where
         T: Real,
         Y: State<T>,
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         // Direction of integration
         let posneg = (tf - t0).signum();
@@ -178,7 +178,7 @@ impl InitialStepSize<Delay> {
     where
         T: Real,
         Y: State<T>,
-        F: DDE<L, T, Y>,
+        F: DDE<L, T, Y> + ?Sized,
     {
         let posneg_init = (tf - t0).signum();
         let n_dim = y0.len();
@@ -349,7 +349,7 @@ impl InitialStepSize<Algebraic> {
     where
         T: Real,
         Y: State<T>,
-        F: DAE<T, Y>,
+        F: DAE<T, Y> + ?Sized,
     {
         let posneg = (tf - t0).signum();
         let dim = y0.len();

--- a/src/methods/irk/adaptive/ordinary.rs
+++ b/src/methods/irk/adaptive/ordinary.rs
@@ -17,7 +17,7 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
 {
     fn init<F>(&mut self, ode: &F, t0: T, tf: T, y0: &Y) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 
@@ -76,7 +76,7 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
 
     fn step<F>(&mut self, ode: &F) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 

--- a/src/methods/irk/fixed/ordinary.rs
+++ b/src/methods/irk/fixed/ordinary.rs
@@ -17,7 +17,7 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
 {
     fn init<F>(&mut self, ode: &F, t0: T, tf: T, y0: &Y) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 
@@ -67,7 +67,7 @@ impl<T: Real, Y: State<T>, const O: usize, const S: usize, const I: usize>
 
     fn step<F>(&mut self, ode: &F) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 

--- a/src/methods/irk/radau/algebraic.rs
+++ b/src/methods/irk/radau/algebraic.rs
@@ -14,7 +14,7 @@ use crate::{
 impl<T: Real, Y: State<T>> AlgebraicNumericalMethod<T, Y> for Radau5<Algebraic, T, Y> {
     fn init<F>(&mut self, dae: &F, t0: T, tf: T, y0: &Y) -> Result<Evals, Error<T, Y>>
     where
-        F: DAE<T, Y>,
+        F: DAE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 
@@ -53,7 +53,7 @@ impl<T: Real, Y: State<T>> AlgebraicNumericalMethod<T, Y> for Radau5<Algebraic, 
 
     fn step<F>(&mut self, dae: &F) -> Result<Evals, Error<T, Y>>
     where
-        F: DAE<T, Y>,
+        F: DAE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 

--- a/src/methods/irk/radau/ordinary.rs
+++ b/src/methods/irk/radau/ordinary.rs
@@ -14,7 +14,7 @@ use crate::{
 impl<T: Real, Y: State<T>> OrdinaryNumericalMethod<T, Y> for Radau5<Ordinary, T, Y> {
     fn init<F>(&mut self, ode: &F, t0: T, tf: T, y0: &Y) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 
@@ -52,7 +52,7 @@ impl<T: Real, Y: State<T>> OrdinaryNumericalMethod<T, Y> for Radau5<Ordinary, T,
 
     fn step<F>(&mut self, ode: &F) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>,
+        F: ODE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 

--- a/src/methods/milstein.rs
+++ b/src/methods/milstein.rs
@@ -75,7 +75,7 @@ impl<T: Real, Y: State<T>> Milstein<T, Y> {
 impl<T: Real, Y: State<T>> StochasticNumericalMethod<T, Y> for Milstein<T, Y> {
     fn init<F>(&mut self, sde: &mut F, t0: T, tf: T, y0: &Y) -> Result<Evals, Error<T, Y>>
     where
-        F: SDE<T, Y>,
+        F: SDE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 
@@ -106,7 +106,7 @@ impl<T: Real, Y: State<T>> StochasticNumericalMethod<T, Y> for Milstein<T, Y> {
 
     fn step<F>(&mut self, sde: &mut F) -> Result<Evals, Error<T, Y>>
     where
-        F: SDE<T, Y>,
+        F: SDE<T, Y> + ?Sized,
     {
         let mut evals = Evals::new();
 

--- a/src/ode/numerical_method.rs
+++ b/src/ode/numerical_method.rs
@@ -29,7 +29,7 @@ where
     ///
     fn init<F>(&mut self, ode: &F, t0: T, tf: T, y0: &Y) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>;
+        F: ODE<T, Y> + ?Sized;
 
     /// Advance the solution by one step
     ///
@@ -41,7 +41,7 @@ where
     ///
     fn step<F>(&mut self, ode: &F) -> Result<Evals, Error<T, Y>>
     where
-        F: ODE<T, Y>;
+        F: ODE<T, Y> + ?Sized;
 
     // Accessors
 

--- a/src/ode/solve.rs
+++ b/src/ode/solve.rs
@@ -124,9 +124,9 @@ pub fn solve_ode<T, Y, S, F, O>(
 where
     T: Real,
     Y: State<T>,
-    F: ODE<T, Y>,
-    S: OrdinaryNumericalMethod<T, Y> + Interpolation<T, Y>,
-    O: Solout<T, Y>,
+    F: ODE<T, Y> + ?Sized,
+    S: OrdinaryNumericalMethod<T, Y> + Interpolation<T, Y> + ?Sized,
+    O: Solout<T, Y> + ?Sized,
 {
     // Initialize the Solution object
     let mut solution = Solution::new();

--- a/src/sde/numerical_method.rs
+++ b/src/sde/numerical_method.rs
@@ -29,7 +29,7 @@ where
     ///
     fn init<F>(&mut self, sde: &mut F, t0: T, tf: T, y0: &Y) -> Result<Evals, Error<T, Y>>
     where
-        F: SDE<T, Y>;
+        F: SDE<T, Y> + ?Sized;
 
     /// Advance the solution by one step
     ///
@@ -41,7 +41,7 @@ where
     ///
     fn step<F>(&mut self, sde: &mut F) -> Result<Evals, Error<T, Y>>
     where
-        F: SDE<T, Y>;
+        F: SDE<T, Y> + ?Sized;
 
     // Accessors
 

--- a/src/sde/solve.rs
+++ b/src/sde/solve.rs
@@ -143,9 +143,9 @@ pub fn solve_sde<T, Y, S, F, O>(
 where
     T: Real,
     Y: State<T>,
-    F: SDE<T, Y>,
-    S: StochasticNumericalMethod<T, Y> + Interpolation<T, Y>,
-    O: Solout<T, Y>,
+    F: SDE<T, Y> + ?Sized,
+    S: StochasticNumericalMethod<T, Y> + Interpolation<T, Y> + ?Sized,
+    O: Solout<T, Y> + ?Sized,
 {
     // Initialize the Solution object
     let mut solution = Solution::new();

--- a/src/solout/crossing.rs
+++ b/src/solout/crossing.rs
@@ -193,7 +193,7 @@ where
         solution: &mut Solution<T, Y>,
     ) -> ControlFlag<T, Y>
     where
-        I: Interpolation<T, Y>,
+        I: Interpolation<T, Y> + ?Sized,
     {
         // Calculate the offset from threshold (to detect zero-crossing)
         let current_value = y_curr.get_component(self.component_idx);
@@ -259,7 +259,7 @@ impl<T: Real> CrossingSolout<T> {
         offset_upper: T,
     ) -> Option<T>
     where
-        I: Interpolation<T, Y>,
+        I: Interpolation<T, Y> + ?Sized,
         Y: State<T>,
     {
         // Start with linear interpolation as initial guess

--- a/src/solout/default.rs
+++ b/src/solout/default.rs
@@ -85,7 +85,7 @@ where
         solution: &mut Solution<T, Y>,
     ) -> ControlFlag<T, Y>
     where
-        I: Interpolation<T, Y>,
+        I: Interpolation<T, Y> + ?Sized,
     {
         // Output the current time and state to the vectors
         solution.push(t_curr, y_curr.clone());

--- a/src/solout/dense.rs
+++ b/src/solout/dense.rs
@@ -91,7 +91,7 @@ where
         solution: &mut Solution<T, Y>,
     ) -> ControlFlag<T, Y>
     where
-        I: Interpolation<T, Y>,
+        I: Interpolation<T, Y> + ?Sized,
     {
         // Interpolate between steps
         if t_prev != t_curr {

--- a/src/solout/even.rs
+++ b/src/solout/even.rs
@@ -94,7 +94,7 @@ where
         solution: &mut Solution<T, Y>,
     ) -> ControlFlag<T, Y>
     where
-        I: Interpolation<T, Y>,
+        I: Interpolation<T, Y> + ?Sized,
     {
         // Determine the alignment offset (remainder when divided by dt)
         let offset = self.t0 % self.dt;

--- a/src/solout/event.rs
+++ b/src/solout/event.rs
@@ -64,7 +64,7 @@ pub trait Event<T: Real = f64, Y: State<T> = DefaultState<T>> {
 /// high accuracy. The event point `(t_event, y_event)` is then appended to the solution. Depending
 /// on the `EventConfig::terminate` setting the integration may terminate after collecting the
 /// specified number of events.
-pub struct EventSolout<'a, T: Real, Y: State<T>, E: Event<T, Y>> {
+pub struct EventSolout<'a, T: Real, Y: State<T>, E: Event<T, Y> + ?Sized> {
     /// User provided event object implementing `Event`
     event: &'a E,
     /// Configuration (direction filtering and termination count)
@@ -83,7 +83,7 @@ pub struct EventSolout<'a, T: Real, Y: State<T>, E: Event<T, Y>> {
     _marker: std::marker::PhantomData<Y>,
 }
 
-impl<'a, T: Real, Y: State<T>, E: Event<T, Y>> EventSolout<'a, T, Y, E> {
+impl<'a, T: Real, Y: State<T>, E: Event<T, Y> + ?Sized> EventSolout<'a, T, Y, E> {
     pub fn new(event: &'a E, t0: T, tf: T) -> Self {
         let direction = (tf - t0).signum();
         let config = event.config();
@@ -218,7 +218,7 @@ impl<'a, T, Y, E> Solout<T, Y> for EventSolout<'a, T, Y, E>
 where
     T: Real,
     Y: State<T>,
-    E: Event<T, Y>,
+    E: Event<T, Y> + ?Sized,
 {
     fn solout<I>(
         &mut self,
@@ -299,7 +299,7 @@ where
 pub struct EventWrappedSolout<'a, T: Real, Y: State<T>, O, E>
 where
     O: Solout<T, Y>,
-    E: Event<T, Y>,
+    E: Event<T, Y> + ?Sized,
 {
     base: O,
     event: &'a E,
@@ -315,7 +315,7 @@ where
 impl<'a, T: Real, Y: State<T>, O, E> EventWrappedSolout<'a, T, Y, O, E>
 where
     O: Solout<T, Y>,
-    E: Event<T, Y>,
+    E: Event<T, Y> + ?Sized,
 {
     pub fn new(base: O, event: &'a E, t0: T, tf: T) -> Self {
         let config = event.config();
@@ -494,7 +494,7 @@ where
     T: Real,
     Y: State<T>,
     O: Solout<T, Y>,
-    E: Event<T, Y>,
+    E: Event<T, Y> + ?Sized,
 {
     fn solout<I>(
         &mut self,

--- a/src/solout/event.rs
+++ b/src/solout/event.rs
@@ -110,7 +110,7 @@ impl<'a, T: Real, Y: State<T>, E: Event<T, Y> + ?Sized> EventSolout<'a, T, Y, E>
         interpolator: &mut I,
     ) -> Option<T>
     where
-        I: Interpolation<T, Y>,
+        I: Interpolation<T, Y> + ?Sized,
     {
         // Ensure that |f(a)| < |f(b)| swapping if necessary
         if fa.abs() < fb.abs() {
@@ -230,7 +230,7 @@ where
         solution: &mut Solution<T, Y>,
     ) -> ControlFlag<T, Y>
     where
-        I: Interpolation<T, Y>,
+        I: Interpolation<T, Y> + ?Sized,
     {
         // Evaluate event function at current endpoint
         let g_curr = self.event.event(t_curr, y_curr);
@@ -342,7 +342,7 @@ where
         solution: &mut Solution<T, Y>,
     ) -> ControlFlag<T, Y>
     where
-        I: Interpolation<T, Y>,
+        I: Interpolation<T, Y> + ?Sized,
     {
         let g_curr = self.event.event(t_curr, y_curr);
         let g_prev = match self.last_g {
@@ -401,7 +401,7 @@ where
         interpolator: &mut I,
     ) -> Option<T>
     where
-        I: Interpolation<T, Y>,
+        I: Interpolation<T, Y> + ?Sized,
     {
         if fa.abs() < fb.abs() {
             std::mem::swap(&mut a, &mut b);
@@ -506,7 +506,7 @@ where
         solution: &mut Solution<T, Y>,
     ) -> ControlFlag<T, Y>
     where
-        I: Interpolation<T, Y>,
+        I: Interpolation<T, Y> + ?Sized,
     {
         let flag = self
             .base

--- a/src/solout/hyperplane.rs
+++ b/src/solout/hyperplane.rs
@@ -210,7 +210,7 @@ where
         solution: &mut Solution<T, Y2>,
     ) -> ControlFlag<T, Y2>
     where
-        I: Interpolation<T, Y2>,
+        I: Interpolation<T, Y2> + ?Sized,
     {
         // Extract position from current state and calculate distance
         let pos_curr = (self.extractor)(y_curr);
@@ -283,7 +283,7 @@ where
         dist_upper: T,
     ) -> Option<T>
     where
-        I: Interpolation<T, Y2>,
+        I: Interpolation<T, Y2> + ?Sized,
     {
         // Start with linear interpolation as initial guess
         let mut t = t_lower - dist_lower * (t_upper - t_lower) / (dist_upper - dist_lower);

--- a/src/solout/solout.rs
+++ b/src/solout/solout.rs
@@ -27,5 +27,5 @@ where
         solution: &mut Solution<T, Y>,
     ) -> ControlFlag<T, Y>
     where
-        I: Interpolation<T, Y>;
+        I: Interpolation<T, Y> + ?Sized;
 }

--- a/src/solout/t_eval.rs
+++ b/src/solout/t_eval.rs
@@ -94,7 +94,7 @@ where
         solution: &mut Solution<T, Y>,
     ) -> ControlFlag<T, Y>
     where
-        I: Interpolation<T, Y>,
+        I: Interpolation<T, Y> + ?Sized,
     {
         // Process evaluation points that fall within current step
         let mut idx = self.next_eval_idx;


### PR DESCRIPTION
I was working on something where I had a list of heterogenous `Event` implementors expressed as `&dyn Event`, but the lib would not allow these to be passed as `Event`s. I noticed that nothing in the actual library requires `Sized`, so I went ahead and added `?Sized` specifications. I subsequently noticed that this was also true about a few other traits, so even though I only really need this for `Event`, I added `?Sized` for those traits too. There's probably several other places where this is the case that I don't know about, since I'm not familiar with this codebase.