### PR TITLE
Remove `timer` from `Solution` on WASM

### DIFF
--- a/src/dae/solve_ivp.rs
+++ b/src/dae/solve_ivp.rs
@@ -99,6 +99,7 @@ where
     let mut solution = Solution::new();
 
     // Begin timing the solution process
+    #[cfg(not(target_arch = "wasm32"))]
     solution.timer.start();
 
     // Determine integration direction and check that tf != t0
@@ -143,6 +144,7 @@ where
         }
         ControlFlag::Terminate => {
             solution.status = Status::Interrupted;
+            #[cfg(not(target_arch = "wasm32"))]
             solution.timer.complete();
             return Ok(solution);
         }
@@ -164,6 +166,7 @@ where
                 // Set the status to complete and finalize the solution
                 solver.set_status(Status::Complete);
                 solution.status = Status::Complete;
+                #[cfg(not(target_arch = "wasm32"))]
                 solution.timer.complete();
                 return Ok(solution);
             }
@@ -217,6 +220,7 @@ where
             }
             ControlFlag::Terminate => {
                 solution.status = Status::Interrupted;
+                #[cfg(not(target_arch = "wasm32"))]
                 solution.timer.complete();
                 return Ok(solution);
             }
@@ -233,6 +237,7 @@ where
 
     // Finalize the solution
     solution.status = Status::Complete;
+    #[cfg(not(target_arch = "wasm32"))]
     solution.timer.complete();
 
     Ok(solution)

--- a/src/dde/solve_ivp.rs
+++ b/src/dde/solve_ivp.rs
@@ -80,6 +80,7 @@ where
 {
     // Initialize the Solution object
     let mut solution = Solution::new();
+    #[cfg(not(target_arch = "wasm32"))]
     solution.timer.start();
 
     // Determine integration direction and check tf != t0
@@ -124,6 +125,7 @@ where
         }
         ControlFlag::Terminate => {
             solution.status = Status::Interrupted;
+            #[cfg(not(target_arch = "wasm32"))]
             solution.timer.complete();
             return Ok(solution);
         }
@@ -145,6 +147,7 @@ where
                 // Set the status to complete and finalize the solution
                 solver.set_status(Status::Complete);
                 solution.status = Status::Complete;
+                #[cfg(not(target_arch = "wasm32"))]
                 solution.timer.complete();
                 return Ok(solution);
             }
@@ -193,6 +196,7 @@ where
             }
             ControlFlag::Terminate => {
                 solution.status = Status::Interrupted;
+                #[cfg(not(target_arch = "wasm32"))]
                 solution.timer.complete();
                 return Ok(solution);
             }
@@ -207,6 +211,7 @@ where
     solver.set_status(Status::Complete);
 
     solution.status = Status::Complete;
+    #[cfg(not(target_arch = "wasm32"))]
     solution.timer.complete();
 
     Ok(solution)

--- a/src/ode/solve_ivp.rs
+++ b/src/ode/solve_ivp.rs
@@ -132,6 +132,7 @@ where
     let mut solution = Solution::new();
 
     // Begin timing the solution process
+    #[cfg(not(target_arch = "wasm32"))]
     solution.timer.start();
 
     // Determine integration direction and check that tf != t0
@@ -176,6 +177,7 @@ where
         }
         ControlFlag::Terminate => {
             solution.status = Status::Interrupted;
+            #[cfg(not(target_arch = "wasm32"))]
             solution.timer.complete();
             return Ok(solution);
         }
@@ -197,6 +199,7 @@ where
                 // Set the status to complete and finalize the solution
                 solver.set_status(Status::Complete);
                 solution.status = Status::Complete;
+                #[cfg(not(target_arch = "wasm32"))]
                 solution.timer.complete();
                 return Ok(solution);
             }
@@ -250,6 +253,7 @@ where
             }
             ControlFlag::Terminate => {
                 solution.status = Status::Interrupted;
+                #[cfg(not(target_arch = "wasm32"))]
                 solution.timer.complete();
                 return Ok(solution);
             }
@@ -266,6 +270,7 @@ where
 
     // Finalize the solution
     solution.status = Status::Complete;
+    #[cfg(not(target_arch = "wasm32"))]
     solution.timer.complete();
 
     Ok(solution)

--- a/src/sde/solve_ivp.rs
+++ b/src/sde/solve_ivp.rs
@@ -151,6 +151,7 @@ where
     let mut solution = Solution::new();
 
     // Begin timing the solution process
+    #[cfg(not(target_arch = "wasm32"))]
     solution.timer.start();
 
     // Determine integration direction and check that tf != t0
@@ -195,6 +196,7 @@ where
         }
         ControlFlag::Terminate => {
             solution.status = Status::Interrupted;
+            #[cfg(not(target_arch = "wasm32"))]
             solution.timer.complete();
             return Ok(solution);
         }
@@ -216,6 +218,7 @@ where
                 // Set the status to complete and finalize the solution
                 solver.set_status(Status::Complete);
                 solution.status = Status::Complete;
+                #[cfg(not(target_arch = "wasm32"))]
                 solution.timer.complete();
                 return Ok(solution);
             }
@@ -260,6 +263,7 @@ where
             }
             ControlFlag::Terminate => {
                 solution.status = Status::Interrupted;
+                #[cfg(not(target_arch = "wasm32"))]
                 solution.timer.complete();
                 return Ok(solution);
             }
@@ -276,6 +280,7 @@ where
 
     // Finalize the solution
     solution.status = Status::Complete;
+    #[cfg(not(target_arch = "wasm32"))]
     solution.timer.complete();
 
     Ok(solution)

--- a/src/solution.rs
+++ b/src/solution.rs
@@ -45,6 +45,7 @@ where
     pub steps: Steps,
 
     /// Timer tracking wall-clock time. `Running` during solving, `Completed` after finalization.
+    #[cfg(not(target_arch = "wasm32"))]
     pub timer: Timer<T>,
 }
 
@@ -72,6 +73,7 @@ where
             status: Status::Uninitialized,
             evals: Evals::new(),
             steps: Steps::new(),
+            #[cfg(not(target_arch = "wasm32"))]
             timer: Timer::Off,
         }
     }
@@ -87,6 +89,7 @@ where
             status: Status::Uninitialized,
             evals: Evals::new(),
             steps: Steps::new(),
+            #[cfg(not(target_arch = "wasm32"))]
             timer: Timer::Off,
         }
     }


### PR DESCRIPTION
I was trying to compile my project to WebAssembly and it turned out the only obstacle to it working was the clock-time timer functionality using `std::time::Instant::now()`, which WebAssembly does not support. This PR just adds some `#[cfg(…)]` directives to make this functionality not exist when compiling for WASM.
